### PR TITLE
[#17] Feat: Authorization 헤더 기반 회원 정보 조회 기능

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
@@ -29,6 +29,14 @@ public class MemberController {
         return ResponseEntity.ok(Map.of("message", "getMemberSuccess", "data", dto));
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<?> getByAuthHeader(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        MemberResponseDTO dto = memberService.get(authorizationHeader);
+        return ResponseEntity.ok(Map.of("message", "getMemberSuccess", "data", dto));
+    }
+
     @PostMapping("/social")
     public ResponseEntity<?> registerOAuthUser(
             @Valid @RequestBody MemberOAuthSignupRequestDTO dto,

--- a/src/main/java/com/tebutebu/apiserver/service/MemberService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberService.java
@@ -14,6 +14,9 @@ public interface MemberService {
     @Transactional(readOnly = true)
     MemberResponseDTO get(Long memberId);
 
+    @Transactional(readOnly = true)
+    MemberResponseDTO get(String authorizationHeader);
+
     MemberSignupResponseDTO registerOAuthUser(MemberOAuthSignupRequestDTO dto, HttpServletResponse response);
 
     void modify(String authorizationHeader, MemberUpdateRequestDTO dto);

--- a/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
@@ -57,6 +57,14 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public MemberResponseDTO get(String authorizationHeader) {
+        Long memberId = extractMemberIdFromHeader(authorizationHeader);
+        Member member = memberRepository.findByIdWithTeam(memberId)
+                .orElseThrow(() -> new NoSuchElementException("userNotFound"));
+        return entityToDTO(member);
+    }
+
+    @Override
     public MemberSignupResponseDTO registerOAuthUser(MemberOAuthSignupRequestDTO dto,
                                                      HttpServletResponse response) {
 


### PR DESCRIPTION
## ⭐ Key Changes

1. GET /api/members/me 엔드포인트 추가
2. Authorization 헤더에서 JWT 토큰을 파싱하여 본인 회원 정보 조회 로직 구현
3. `MemberService#get(String authorizationHeader)` 메서드 오버로드로 인증된 사용자 조회 로직 분리

<br />

## 🖐️ To reviewers

1. Admin 권한으로 팀 생성·관리 로직과 어떻게 연결할지 아이디어가 있으면 부탁드립니다.
2. `/api/members/me` 엔드포인트에 필요한 권한 설정 검토 부탁드립니다.

<br />

## 📌 issue

- close #17
