### PR TITLE
[#9] Feat: 프로젝트 도메인 관련 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.5'
@@ -58,6 +64,13 @@ dependencies {
 
 	implementation platform("software.amazon.awssdk:bom:2.27.21")
 	implementation "software.amazon.awssdk:s3"
+
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+	annotationProcessor(
+			"jakarta.persistence:jakarta.persistence-api",
+			"jakarta.annotation:jakarta.annotation-api",
+			"com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+	)
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tebutebu/apiserver/config/QueryDslConfig.java
+++ b/src/main/java/com/tebutebu/apiserver/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.tebutebu.apiserver.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
@@ -29,6 +29,14 @@ public class MemberController {
         return ResponseEntity.ok(Map.of("message", "getMemberSuccess", "data", dto));
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<?> getByAuthHeader(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        MemberResponseDTO dto = memberService.get(authorizationHeader);
+        return ResponseEntity.ok(Map.of("message", "getMemberSuccess", "data", dto));
+    }
+
     @PostMapping("/social")
     public ResponseEntity<?> registerOAuthUser(
             @Valid @RequestBody MemberOAuthSignupRequestDTO dto,

--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -1,0 +1,55 @@
+package com.tebutebu.apiserver.controller;
+
+import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
+import com.tebutebu.apiserver.dto.project.request.ProjectUpdateRequestDTO;
+import com.tebutebu.apiserver.dto.project.response.ProjectResponseDTO;
+import com.tebutebu.apiserver.service.ProjectService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@Log4j2
+@RequestMapping("/api/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    @GetMapping("/{projectId}")
+    public ResponseEntity<?> get(@PathVariable long projectId) {
+        ProjectResponseDTO dto = projectService.get(projectId);
+        return ResponseEntity.ok(Map.of("message", "getProjectSuccess", "data", dto));
+    }
+
+    @PostMapping("")
+    public ResponseEntity<?> register(@Valid @RequestBody ProjectCreateRequestDTO dto) {
+        long projectId = projectService.register(dto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Map.of(
+                        "message", "projectCreated",
+                        "data", Map.of("id", projectId)
+                ));
+    }
+
+    @PutMapping("/{projectId}")
+    public ResponseEntity<?> modify(
+            @PathVariable long projectId,
+            @Valid @RequestBody ProjectUpdateRequestDTO dto
+    ) {
+        projectService.modify(projectId, dto);
+        return ResponseEntity.ok(Map.of("message", "updateProjectSuccess"));
+    }
+
+    @DeleteMapping("/{projectId}")
+    public ResponseEntity<?> delete(@PathVariable long projectId) {
+        projectService.delete(projectId);
+        return ResponseEntity.ok(Map.of("message", "projectDeleted"));
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -3,8 +3,13 @@ package com.tebutebu.apiserver.controller;
 import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.project.response.ProjectResponseDTO;
+import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
+import com.tebutebu.apiserver.pagination.dto.response.CursorPageResponseDTO;
 import com.tebutebu.apiserver.service.ProjectService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
@@ -26,6 +31,27 @@ public class ProjectController {
         ProjectResponseDTO dto = projectService.get(projectId);
         return ResponseEntity.ok(Map.of("message", "getProjectSuccess", "data", dto));
     }
+
+    @GetMapping(params = "sort=rank")
+    public ResponseEntity<?> scrollRanking(
+            @RequestParam(name = "context-id", required = false) Long contextId,
+            @RequestParam(name = "cursor-id", required = false) Long cursorId,
+            @RequestParam(name = "page-size", defaultValue = "10") @Positive @Min(1) @Max(100) Integer pageSize
+    ) {
+        CursorPageRequestDTO dto = CursorPageRequestDTO.builder()
+                .contextId(contextId)
+                .cursorId(cursorId)
+                .cursorTime(null)
+                .pageSize(pageSize)
+                .build();
+        CursorPageResponseDTO<ProjectResponseDTO> page = projectService.getRankingPage(dto);
+        return ResponseEntity.ok(Map.of(
+                "message", "getRankingPageSuccess",
+                "data", page.getData(),
+                "meta", page.getMeta()
+        ));
+    }
+
 
     @PostMapping("")
     public ResponseEntity<?> register(@Valid @RequestBody ProjectCreateRequestDTO dto) {

--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -15,10 +15,12 @@ import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @RestController
@@ -59,6 +61,26 @@ public class ProjectController {
         CursorPageResponseDTO<ProjectResponseDTO> page = projectService.getRankingPage(dto);
         return ResponseEntity.ok(Map.of(
                 "message", "getRankingPageSuccess",
+                "data", page.getData(),
+                "meta", page.getMeta()
+        ));
+    }
+
+    @GetMapping(params = "sort=latest")
+    public ResponseEntity<?> scrollLatest(
+            @RequestParam(name = "cursor-id", defaultValue = "0") @PositiveOrZero Long cursorId,
+            @RequestParam(name = "cursor-time", defaultValue = "#{T(java.time.LocalDateTime).now().format(T(java.time.format.DateTimeFormatter).ISO_DATE_TIME)}")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorTime,
+            @RequestParam(name = "page-size", defaultValue = "10") @Positive @Min(1) @Max(100) Integer pageSize
+    ) {
+        CursorPageRequestDTO dto = CursorPageRequestDTO.builder()
+                .cursorId(cursorId)
+                .cursorTime(cursorTime)
+                .pageSize(pageSize)
+                .build();
+        CursorPageResponseDTO<ProjectResponseDTO> page = projectService.getLatestPage(dto);
+        return ResponseEntity.ok(Map.of(
+                "message", "getLatestPageSuccess",
                 "data", page.getData(),
                 "meta", page.getMeta()
         ));

--- a/src/main/java/com/tebutebu/apiserver/domain/Project.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Project.java
@@ -1,0 +1,118 @@
+package com.tebutebu.apiserver.domain;
+
+import com.tebutebu.apiserver.domain.common.TimeStampedEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString(exclude = {"team", "images", "projectTags", "tagContents"})
+public class Project extends TimeStampedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @NotBlank(message = "제목은 필수 입력 값입니다.")
+    @Column(nullable = false, length = 64)
+    private String title;
+
+    @NotBlank(message = "소개는 필수 입력 값입니다.")
+    @Column(length = 150)
+    private String introduction;
+
+    @NotBlank(message = "상세 설명은 필수 입력 값입니다.")
+    @Column(name = "detailed_description", length = 1000)
+    private String detailedDescription;
+
+    @NotBlank(message = "대표 이미지 URL은 필수 입력 값입니다.")
+    @Column(name = "representative_image_url", length = 512)
+    private String representativeImageUrl;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectImage> images = new ArrayList<>();
+
+    @NotBlank(message = "배포 URL은 필수 입력 값입니다.")
+    @Column(name = "deployment_url", length = 512)
+    private String deploymentUrl;
+
+    @NotBlank(message = "깃허브 URL은 필수 입력 값입니다.")
+    @Column(name = "github_url", length = 512)
+    private String githubUrl;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectTag> projectTags = new ArrayList<>();
+
+    @Builder.Default
+    @ElementCollection
+    @CollectionTable(
+            name = "project_tag_contents",
+            joinColumns = @JoinColumn(name = "project_id")
+    )
+    @Column(name = "tag_content")
+    private List<String> tagContents = new ArrayList<>();
+
+    public void changeTitle(String title) {
+        this.title = title;
+    }
+
+    public void changeIntroduction(String introduction) {
+        this.introduction = introduction;
+    }
+
+    public void changeDetailedDescription(String detailedDescription) {
+        this.detailedDescription = detailedDescription;
+    }
+
+    public void changeRepresentativeImageUrl(String representativeImageUrl) {
+        this.representativeImageUrl = representativeImageUrl;
+    }
+
+    public void changeDeploymentUrl(String deploymentUrl) {
+        this.deploymentUrl = deploymentUrl;
+    }
+
+    public void changeGithubUrl(String githubUrl) {
+        this.githubUrl = githubUrl;
+    }
+
+    public void addTag(Tag tag) {
+        ProjectTag pt = ProjectTag.builder()
+                .project(this)
+                .tag(tag)
+                .build();
+        this.projectTags.add(pt);
+        tag.getProjectTags().add(pt);
+    }
+
+    public void replaceTags(List<Tag> tags) {
+        this.projectTags.clear();
+        if (tags != null) {
+            tags.forEach(this::addTag);
+        }
+    }
+
+    public void changeTagContents(List<String> contents) {
+        this.tagContents.clear();
+        if (contents != null) this.tagContents.addAll(contents);
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/domain/ProjectImage.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/ProjectImage.java
@@ -1,0 +1,38 @@
+package com.tebutebu.apiserver.domain;
+
+import com.tebutebu.apiserver.domain.common.TimeStampedEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString(exclude = "project")
+public class ProjectImage extends TimeStampedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Column(name = "image_url", nullable = false, length = 512)
+    private String url;
+
+    @Column(nullable = false)
+    private Integer sequence;
+
+    public void changeProject(Project project) {
+        this.project = project;
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/domain/ProjectRankingSnapshot.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/ProjectRankingSnapshot.java
@@ -1,0 +1,31 @@
+package com.tebutebu.apiserver.domain;
+
+import com.tebutebu.apiserver.domain.common.TimeStampedEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString
+public class ProjectRankingSnapshot extends TimeStampedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @Column(name="ranking_data", columnDefinition="JSON")
+    private String rankingData;
+
+    private LocalDateTime requestedAt;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/domain/ProjectTag.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/ProjectTag.java
@@ -1,0 +1,31 @@
+package com.tebutebu.apiserver.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString(exclude = {"project", "tag"})
+public class ProjectTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "tag_id")
+    private Tag tag;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/domain/Tag.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Tag.java
@@ -1,0 +1,38 @@
+package com.tebutebu.apiserver.domain;
+
+import com.tebutebu.apiserver.domain.common.TimeStampedEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString(exclude = "projectTags")
+public class Tag extends TimeStampedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @NotBlank(message = "태그는 필수 입력 값입니다.")
+    @Pattern(regexp = "^\\S{2,20}$", message = "태그 내용은 공백을 포함할 수 없으며 2자 이상 20자 이하여야 합니다.")
+    @Column(nullable = false, unique = true, length = 20)
+    private String content;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "tag", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectTag> projectTags = new ArrayList<>();
+
+}

--- a/src/main/java/com/tebutebu/apiserver/domain/Team.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Team.java
@@ -52,9 +52,11 @@ public class Team extends TimeStampedEntity {
     List<Member> members;
 
     @Builder.Default
+    @Column(columnDefinition = "INT UNSIGNED")
     private Long givedPumatiCount = 0L;
 
     @Builder.Default
+    @Column(columnDefinition = "INT UNSIGNED")
     private Long receivedPumatiCount = 0L;
 
     @Size(max = 512, message = "이미지 URL은 최대 512자까지 가능합니다.")

--- a/src/main/java/com/tebutebu/apiserver/dto/project/image/request/ProjectImageRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/project/image/request/ProjectImageRequestDTO.java
@@ -1,0 +1,31 @@
+package com.tebutebu.apiserver.dto.project.image.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProjectImageRequestDTO {
+
+    @NotNull(message = "프로젝트 ID는 필수 입력 값입니다.")
+    @Positive(message = "프로젝트 ID는 양수여야 합니다.")
+    private Long projectId;
+
+    @NotBlank(message = "프로젝트 이미지 URL은 필수 입력 값입니다.")
+    @Size(max = 512, message = "프로젝트 이미지 URL은 최대 512자까지 가능합니다.")
+    private String url;
+
+    @NotNull(message = "프로젝트 이미지 순서는 필수 입력 값입니다.")
+    private Integer sequence;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/project/image/response/ProjectImageResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/project/image/response/ProjectImageResponseDTO.java
@@ -1,0 +1,24 @@
+package com.tebutebu.apiserver.dto.project.image.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProjectImageResponseDTO {
+
+    private Long id;
+
+    private Long projectId;
+
+    private String url;
+
+    private Integer sequence;
+
+    private LocalDateTime createdAt, modifiedAt;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/project/request/ProjectCreateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/project/request/ProjectCreateRequestDTO.java
@@ -1,0 +1,51 @@
+package com.tebutebu.apiserver.dto.project.request;
+
+import com.tebutebu.apiserver.dto.project.image.request.ProjectImageRequestDTO;
+import com.tebutebu.apiserver.dto.tag.request.TagCreateRequestDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProjectCreateRequestDTO {
+
+    @NotNull(message = "팀 ID는 필수 입력 값입니다.")
+    private Long teamId;
+
+    @NotBlank(message = "제목은 필수 입력 값입니다.")
+    @Size(max = 64, message = "제목은 최대 64자까지 가능합니다.")
+    private String title;
+
+    @Size(max = 150, message = "소개는 최대 150자까지 가능합니다.")
+    private String introduction;
+
+    @Size(max = 1000, message = "상세 설명은 최대 1000자까지 가능합니다.")
+    private String detailedDescription;
+
+    @Size(max = 512, message = "배포 URL은 최대 512자까지 가능합니다.")
+    private String deploymentUrl;
+
+    @Size(max = 512, message = "깃허브 URL은 최대 512자까지 가능합니다.")
+    private String githubUrl;
+
+    @NotNull(message = "태그는 최소 1개 이상 입력해야 합니다.")
+    @Size(min = 1, max = 5, message = "태그는 최소 1개 이상, 최대 5개까지 가능합니다.")
+    private List<@Valid TagCreateRequestDTO> tags;
+
+    @NotNull(message = "프로젝트 이미지는 필수 입력 값입니다.")
+    @Size(min = 1, message = "최소 하나 이상의 이미지를 입력해야 합니다.")
+    private List<ProjectImageRequestDTO> images;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/project/request/ProjectUpdateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/project/request/ProjectUpdateRequestDTO.java
@@ -1,0 +1,47 @@
+package com.tebutebu.apiserver.dto.project.request;
+
+import com.tebutebu.apiserver.dto.project.image.request.ProjectImageRequestDTO;
+import com.tebutebu.apiserver.dto.tag.request.TagCreateRequestDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProjectUpdateRequestDTO {
+
+    @NotBlank(message = "제목은 필수 입력 값입니다.")
+    @Size(max = 64, message = "제목은 최대 64자까지 가능합니다.")
+    private String title;
+
+    @Size(max = 150, message = "소개는 최대 150자까지 가능합니다.")
+    private String introduction;
+
+    @Size(max = 1000, message = "상세 설명은 최대 1000자까지 가능합니다.")
+    private String detailedDescription;
+
+    @Size(max = 512, message = "배포 URL은 최대 512자까지 가능합니다.")
+    private String deploymentUrl;
+
+    @Size(max = 512, message = "깃허브 URL은 최대 512자까지 가능합니다.")
+    private String githubUrl;
+
+    @NotNull(message = "태그는 최소 1개 이상 입력해야 합니다.")
+    @Size(min = 1, max = 5, message = "태그는 최소 1개 이상, 최대 5개까지 가능합니다.")
+    private List<@Valid TagCreateRequestDTO> tags;
+
+    @NotNull(message = "프로젝트 이미지는 필수 입력 값입니다.")
+    @Size(min = 1, message = "최소 하나 이상의 이미지를 입력해야 합니다.")
+    private List<ProjectImageRequestDTO> images;
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/project/response/ProjectResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/project/response/ProjectResponseDTO.java
@@ -18,6 +18,10 @@ public class ProjectResponseDTO {
 
     private Long teamId;
 
+    private Integer term;
+
+    private Integer teamNumber;
+
     private String title;
 
     private String introduction;

--- a/src/main/java/com/tebutebu/apiserver/dto/project/response/ProjectResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/project/response/ProjectResponseDTO.java
@@ -1,0 +1,45 @@
+package com.tebutebu.apiserver.dto.project.response;
+
+import com.tebutebu.apiserver.dto.project.image.response.ProjectImageResponseDTO;
+import com.tebutebu.apiserver.dto.tag.response.TagResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProjectResponseDTO {
+
+    private Long id;
+
+    private Long teamId;
+
+    private String title;
+
+    private String introduction;
+
+    private String detailedDescription;
+
+    private String representativeImageUrl;
+
+    private List<ProjectImageResponseDTO> images;
+
+    private String deploymentUrl;
+
+    private String githubUrl;
+
+    private List<TagResponseDTO> tags;
+
+    private Long givedPumatiCount;
+
+    private Long receivedPumatiCount;
+
+    private String badgeImageUrl;
+
+    private LocalDateTime createdAt, modifiedAt;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/snapshot/response/ProjectRankingSnapshotResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/snapshot/response/ProjectRankingSnapshotResponseDTO.java
@@ -1,0 +1,18 @@
+package com.tebutebu.apiserver.dto.snapshot.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProjectRankingSnapshotResponseDTO {
+
+    private Long id;
+
+    private List<RankingItemDTO> data;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/snapshot/response/RankingItemDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/snapshot/response/RankingItemDTO.java
@@ -1,0 +1,21 @@
+package com.tebutebu.apiserver.dto.snapshot.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RankingItemDTO {
+
+    @JsonProperty("project_id")
+    private Long projectId;
+
+    private Integer rank;
+
+    @JsonProperty("gived_pumati_count")
+    private Long givedPumatiCount;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/tag/request/TagCreateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/tag/request/TagCreateRequestDTO.java
@@ -1,0 +1,24 @@
+package com.tebutebu.apiserver.dto.tag.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagCreateRequestDTO {
+
+    @NotBlank(message = "태그는 필수 입력 값입니다.")
+    @Pattern(regexp = "^\\S{2,20}$", message = "태그 내용은 공백을 포함할 수 없으며 2자 이상 20자 이하여야 합니다.")
+    @Size(min = 2, max = 20, message = "태그는 2자 이상 20자 이하여야 합니다.")
+    private String content;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/tag/response/TagResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/tag/response/TagResponseDTO.java
@@ -1,0 +1,14 @@
+package com.tebutebu.apiserver.dto.tag.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TagResponseDTO {
+
+    private String content;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/team/response/TeamResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/team/response/TeamResponseDTO.java
@@ -17,6 +17,12 @@ public class TeamResponseDTO {
 
     private int number;
 
+    private Long givedPumatiCount;
+
+    private Long receivedPumatiCount;
+
+    private String badgeImageUrl;
+
     private LocalDateTime createdAt, modifiedAt;
 
 }

--- a/src/main/java/com/tebutebu/apiserver/pagination/dto/request/CursorPageRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/pagination/dto/request/CursorPageRequestDTO.java
@@ -1,0 +1,33 @@
+package com.tebutebu.apiserver.pagination.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CursorPageRequestDTO {
+
+    @Positive(message = "컨텍스트 ID는 유효한 컨텍스트 식별자여야 합니다.")
+    private Long contextId;
+
+    @Positive(message = "리소스 ID는 양수여야 합니다.")
+    private Long cursorId;
+
+    private LocalDateTime cursorTime;
+
+    @NotNull(message = "페이지 크기는 필수 입력 값입니다.")
+    @Size(min = 1, max = 100, message = "페이지 크기는 1에서 100 사이여야 합니다.")
+    private Integer pageSize;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/pagination/dto/response/CursorMetaDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/pagination/dto/response/CursorMetaDTO.java
@@ -11,8 +11,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class CursorMetaDTO {
 
-    private Long contextId;
-
     private Long nextCursorId;
 
     private LocalDateTime nextCursorTime;

--- a/src/main/java/com/tebutebu/apiserver/pagination/dto/response/CursorMetaDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/pagination/dto/response/CursorMetaDTO.java
@@ -1,0 +1,22 @@
+package com.tebutebu.apiserver.pagination.dto.response;
+
+import lombok.Getter;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CursorMetaDTO {
+
+    private Long contextId;
+
+    private Long nextCursorId;
+
+    private LocalDateTime nextCursorTime;
+
+    private boolean hasNext;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/pagination/dto/response/CursorPageResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/pagination/dto/response/CursorPageResponseDTO.java
@@ -1,0 +1,18 @@
+package com.tebutebu.apiserver.pagination.dto.response;
+
+import lombok.Getter;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CursorPageResponseDTO<T> {
+
+    private List<T> data;
+
+    private CursorMetaDTO meta;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/pagination/factory/CursorPageFactory.java
+++ b/src/main/java/com/tebutebu/apiserver/pagination/factory/CursorPageFactory.java
@@ -1,0 +1,78 @@
+package com.tebutebu.apiserver.pagination.factory;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tebutebu.apiserver.pagination.internal.CursorPage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CursorPageFactory {
+
+    private final JPAQueryFactory queryFactory;
+
+    public <E> CursorPage<E> create(CursorPageSpec<E> spec) {
+        EntityPathBase<E> entityPath = spec.getEntityPath();
+        BooleanBuilder where = spec.getWhere();
+        OrderSpecifier<?>[] orderBy = spec.getOrderBy();
+        DateTimeExpression<LocalDateTime> createdAtExpr = spec.getCreatedAtExpr();
+        NumberExpression<Long> idExpr = spec.getIdExpr();
+        Long cursorID = spec.getCursorId();
+        LocalDateTime afterTime = spec.getCursorTime();
+        int limit = spec.getPageSize();
+
+        if (cursorID != null && afterTime != null) {
+            where.and(
+                    createdAtExpr.lt(afterTime)
+                            .or(
+                                    createdAtExpr.eq(afterTime)
+                                            .and(idExpr.lt(cursorID)))
+            );
+        }
+
+        List<E> fetched = queryFactory
+                .select(entityPath)
+                .from(entityPath)
+                .where(where)
+                .orderBy(orderBy)
+                .limit(limit + 1)
+                .fetch();
+
+        boolean hasNext = fetched.size() > limit;
+        List<E> pageItems = hasNext ? fetched.subList(0, limit) : fetched;
+
+        if (pageItems.isEmpty()) {
+            return CursorPage.<E>builder()
+                    .items(pageItems)
+                    .nextCursorId(null)
+                    .nextCursorTime(null)
+                    .hasNext(false)
+                    .build();
+        }
+
+        E last = pageItems.get(pageItems.size() - 1);
+        Long nextCursorId;
+        LocalDateTime nextCursorTime;
+        try {
+            nextCursorId = (Long) last.getClass().getMethod("getId").invoke(last);
+            nextCursorTime = (LocalDateTime) last.getClass().getMethod("getCreatedAt").invoke(last);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
+
+        return CursorPage.<E>builder()
+                .items(pageItems)
+                .nextCursorId(nextCursorId)
+                .nextCursorTime(nextCursorTime)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/src/main/java/com/tebutebu/apiserver/pagination/factory/CursorPageSpec.java
+++ b/src/main/java/com/tebutebu/apiserver/pagination/factory/CursorPageSpec.java
@@ -1,0 +1,35 @@
+package com.tebutebu.apiserver.pagination.factory;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.NumberExpression;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CursorPageSpec<E> {
+
+    private EntityPathBase<E> entityPath;
+
+    private BooleanBuilder where;
+
+    private OrderSpecifier<?>[] orderBy;
+
+    private DateTimeExpression<LocalDateTime> createdAtExpr;
+
+    private NumberExpression<Long> idExpr;
+
+    private Long cursorId;
+
+    private LocalDateTime cursorTime;
+
+    private int pageSize;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/pagination/internal/CursorPage.java
+++ b/src/main/java/com/tebutebu/apiserver/pagination/internal/CursorPage.java
@@ -1,0 +1,14 @@
+package com.tebutebu.apiserver.pagination.internal;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record CursorPage<E>(
+        List<E> items,
+        Long nextCursorId,
+        LocalDateTime nextCursorTime,
+        boolean hasNext
+) {}

--- a/src/main/java/com/tebutebu/apiserver/repository/ProjectImageRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/ProjectImageRepository.java
@@ -1,0 +1,21 @@
+package com.tebutebu.apiserver.repository;
+
+import com.tebutebu.apiserver.domain.ProjectImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProjectImageRepository extends JpaRepository<ProjectImage, Long> {
+
+    @Query("SELECT pi FROM ProjectImage pi WHERE pi.project.id = :projectId ORDER BY pi.sequence ASC")
+    Optional<List<ProjectImage>> findByProjectIdOrderBySequenceAsc(@Param("projectId") Long projectId);
+
+    @Query("SELECT pi FROM ProjectImage pi WHERE pi.project.id = :projectId AND pi.sequence = :sequence")
+    Optional<ProjectImage> findByProjectIdAndSequence(@Param("projectId") Long projectId, @Param("sequence") Integer sequence);
+
+    void deleteAllByProjectId(Long projectId);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/ProjectRankingSnapshotRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/ProjectRankingSnapshotRepository.java
@@ -1,0 +1,13 @@
+package com.tebutebu.apiserver.repository;
+
+import com.tebutebu.apiserver.domain.ProjectRankingSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface ProjectRankingSnapshotRepository extends JpaRepository<ProjectRankingSnapshot, Long> {
+
+    Optional<ProjectRankingSnapshot> findTopByRequestedAtAfterOrderByRequestedAtDesc(LocalDateTime time);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/ProjectRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/ProjectRepository.java
@@ -1,0 +1,20 @@
+package com.tebutebu.apiserver.repository;
+
+import com.tebutebu.apiserver.domain.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    @Query("SELECT DISTINCT p FROM Project p "
+            + "LEFT JOIN FETCH p.team t "
+            + "LEFT JOIN FETCH p.images i "
+            + "WHERE p.id = :id")
+    Optional<Project> findProjectWithTeamAndImagesById(@Param("id") Long id);
+
+    boolean existsByTeamId(Long teamId);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/ProjectRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/ProjectRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
@@ -16,5 +17,11 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     Optional<Project> findProjectWithTeamAndImagesById(@Param("id") Long id);
 
     boolean existsByTeamId(Long teamId);
+
+    @Query("SELECT DISTINCT p FROM Project p " +
+            "LEFT JOIN FETCH p.team t " +
+            "LEFT JOIN FETCH p.images i " +
+            "ORDER BY t.givedPumatiCount DESC")
+    List<Project> findAllForRanking();
 
 }

--- a/src/main/java/com/tebutebu/apiserver/repository/TagRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/TagRepository.java
@@ -1,0 +1,12 @@
+package com.tebutebu.apiserver.repository;
+
+import com.tebutebu.apiserver.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByContentIgnoreCase(String content);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/paging/project/ProjectPagingRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/paging/project/ProjectPagingRepository.java
@@ -8,4 +8,6 @@ public interface ProjectPagingRepository {
 
     CursorPage<Project> findByRankingCursor(CursorPageRequestDTO req);
 
+    CursorPage<Project> findByLatestCursor(CursorPageRequestDTO req);
+
 }

--- a/src/main/java/com/tebutebu/apiserver/repository/paging/project/ProjectPagingRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/paging/project/ProjectPagingRepository.java
@@ -1,0 +1,11 @@
+package com.tebutebu.apiserver.repository.paging.project;
+
+import com.tebutebu.apiserver.domain.Project;
+import com.tebutebu.apiserver.pagination.internal.CursorPage;
+import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
+
+public interface ProjectPagingRepository {
+
+    CursorPage<Project> findByRankingCursor(CursorPageRequestDTO req);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/paging/project/ProjectPagingRepositoryImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/paging/project/ProjectPagingRepositoryImpl.java
@@ -1,0 +1,84 @@
+package com.tebutebu.apiserver.repository.paging.project;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tebutebu.apiserver.domain.Project;
+import com.tebutebu.apiserver.domain.ProjectRankingSnapshot;
+import com.tebutebu.apiserver.dto.snapshot.response.RankingItemDTO;
+import com.tebutebu.apiserver.pagination.internal.CursorPage;
+import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
+import com.tebutebu.apiserver.repository.ProjectRankingSnapshotRepository;
+import com.tebutebu.apiserver.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class ProjectPagingRepositoryImpl implements ProjectPagingRepository {
+
+    private final ProjectRankingSnapshotRepository snapshotRepository;
+
+    private final ProjectRepository projectRepository;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public CursorPage<Project> findByRankingCursor(CursorPageRequestDTO req) {
+        ProjectRankingSnapshot snapshot = snapshotRepository.findById(req.getContextId())
+                .orElseThrow(() -> new NoSuchElementException("snapshotNotFound"));
+
+        List<RankingItemDTO> dtoList = parseSnapshotJson(snapshot);
+
+        int start = calculateStartIndex(dtoList, req.getCursorId());
+        int end = Math.min(start + req.getPageSize(), dtoList.size());
+
+        List<Long> projectIds = dtoList.subList(start, end).stream()
+                .map(RankingItemDTO::getProjectId)
+                .collect(Collectors.toList());
+
+        List<Project> projects = projectRepository.findAllById(projectIds).stream()
+                .sorted(Comparator.comparingInt(p -> projectIds.indexOf(p.getId())))
+                .collect(Collectors.toList());
+
+        boolean hasNext = end < dtoList.size();
+        Long nextCursorId = hasNext ? dtoList.get(end - 1).getProjectId() : null;
+
+        return CursorPage.<Project>builder()
+                .items(projects)
+                .nextCursorId(nextCursorId)
+                .nextCursorTime(null)
+                .hasNext(hasNext)
+                .build();
+    }
+
+    private List<RankingItemDTO> parseSnapshotJson(ProjectRankingSnapshot snapshot) {
+        try {
+            Map<String, List<RankingItemDTO>> map = objectMapper.readValue(
+                    snapshot.getRankingData(),
+                    new TypeReference<>() {}
+            );
+            return map.get("projects");
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    private int calculateStartIndex(List<RankingItemDTO> all, Long afterId) {
+        if (afterId == null) {
+            return 0;
+        }
+        for (int i = 0; i < all.size(); i++) {
+            if (all.get(i).getProjectId().equals(afterId)) {
+                return i + 1;
+            }
+        }
+        return 0;
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
+++ b/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
@@ -33,7 +33,7 @@ public class JWTCheckFilter extends OncePerRequestFilter {
         }
 
         if (request.getMethod().equals("GET")) {
-            if (path.equals("/") || path.equals("/docs") || path.startsWith("/api/oauth/") || path.equals("/api/teams")) {
+            if (path.equals("/") || path.equals("/docs") || path.startsWith("/api/oauth/") || path.equals("/api/teams") || path.startsWith("/api/projects")) {
                 return true;
             }
         }

--- a/src/main/java/com/tebutebu/apiserver/service/MemberService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberService.java
@@ -14,6 +14,9 @@ public interface MemberService {
     @Transactional(readOnly = true)
     MemberResponseDTO get(Long memberId);
 
+    @Transactional(readOnly = true)
+    MemberResponseDTO get(String authorizationHeader);
+
     MemberSignupResponseDTO registerOAuthUser(MemberOAuthSignupRequestDTO dto, HttpServletResponse response);
 
     void modify(String authorizationHeader, MemberUpdateRequestDTO dto);

--- a/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
@@ -57,6 +57,14 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public MemberResponseDTO get(String authorizationHeader) {
+        Long memberId = extractMemberIdFromHeader(authorizationHeader);
+        Member member = memberRepository.findByIdWithTeam(memberId)
+                .orElseThrow(() -> new NoSuchElementException("userNotFound"));
+        return entityToDTO(member);
+    }
+
+    @Override
     public MemberSignupResponseDTO registerOAuthUser(MemberOAuthSignupRequestDTO dto,
                                                      HttpServletResponse response) {
 

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectImageService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectImageService.java
@@ -1,0 +1,35 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.ProjectImage;
+import com.tebutebu.apiserver.dto.project.image.request.ProjectImageRequestDTO;
+import com.tebutebu.apiserver.dto.project.image.response.ProjectImageResponseDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+public interface ProjectImageService {
+
+    @Transactional(readOnly = true)
+    List<ProjectImageResponseDTO> getListByProjectId(Long projectId);
+
+    Long register(Long projectId, ProjectImageRequestDTO dto);
+
+    List<Long> updateProjectImages(Long projectId, List<ProjectImageRequestDTO> images);
+
+    void delete(Long projectId, Integer sequence);
+
+    ProjectImage dtoToEntity(ProjectImageRequestDTO dto);
+
+    default ProjectImageResponseDTO entityToDTO(ProjectImage projectImage) {
+        return ProjectImageResponseDTO.builder()
+                .id(projectImage.getId())
+                .projectId(projectImage.getProject().getId())
+                .sequence(projectImage.getSequence())
+                .url(projectImage.getUrl())
+                .createdAt(projectImage.getCreatedAt())
+                .modifiedAt(projectImage.getModifiedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectImageServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectImageServiceImpl.java
@@ -1,0 +1,86 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.Project;
+import com.tebutebu.apiserver.domain.ProjectImage;
+import com.tebutebu.apiserver.dto.project.image.request.ProjectImageRequestDTO;
+import com.tebutebu.apiserver.dto.project.image.response.ProjectImageResponseDTO;
+import com.tebutebu.apiserver.repository.ProjectImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class ProjectImageServiceImpl implements ProjectImageService {
+
+    private final ProjectImageRepository projectImageRepository;
+
+    @Override
+    public List<ProjectImageResponseDTO> getListByProjectId(Long projectId) {
+        Optional<List<ProjectImage>> result = projectImageRepository.findByProjectIdOrderBySequenceAsc(projectId);
+        if (result.isEmpty()) {
+            throw new NoSuchElementException("projectImagesNotFound");
+        }
+
+        return result.get().stream()
+                .map(this::entityToDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Long register(Long projectId, ProjectImageRequestDTO dto) {
+        Optional<List<ProjectImage>> result = projectImageRepository.findByProjectIdOrderBySequenceAsc(projectId);
+        if (result.isEmpty()) {
+            throw new NoSuchElementException("projectImagesNotFound");
+        }
+
+        ProjectImage projectImage = projectImageRepository.save(dtoToEntity(dto));
+        return projectImage.getId();
+    }
+
+    @Override
+    public List<Long> updateProjectImages(Long projectId, List<ProjectImageRequestDTO> images) {
+        Optional<List<ProjectImage>> result = projectImageRepository.findByProjectIdOrderBySequenceAsc(projectId);
+        if (result.isEmpty()) {
+            throw new NoSuchElementException("projectImagesNotFound");
+        }
+
+        projectImageRepository.deleteAllByProjectId(projectId);
+
+        return images.stream()
+                .map(dto -> {
+                    ProjectImage saved = projectImageRepository.save(dtoToEntity(dto));
+                    return saved.getId();
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void delete(Long projectId, Integer sequence) {
+        Optional<List<ProjectImage>> result = projectImageRepository.findByProjectIdOrderBySequenceAsc(projectId);
+        if (result.isEmpty()) {
+            throw new NoSuchElementException("projectImagesNotFound");
+        }
+
+        ProjectImage projectImage = projectImageRepository.findByProjectIdAndSequence(projectId, sequence)
+                .orElseThrow(() -> new NoSuchElementException("projectImageNotFound"));
+
+        projectImageRepository.delete(projectImage);
+    }
+
+    @Override
+    public ProjectImage dtoToEntity(ProjectImageRequestDTO dto) {
+        return ProjectImage.builder()
+                .project(Project.builder().id(dto.getProjectId()).build())
+                .url(dto.getUrl())
+                .sequence(dto.getSequence())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectRankingSnapshotService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectRankingSnapshotService.java
@@ -1,0 +1,25 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.dto.snapshot.response.ProjectRankingSnapshotResponseDTO;
+import com.tebutebu.apiserver.dto.snapshot.response.RankingItemDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+public interface ProjectRankingSnapshotService {
+
+    Long register();
+
+    default ProjectRankingSnapshotResponseDTO entityToDTO(Long snapshotId, Long projectId, Integer rank, Long givedPumatiCount) {
+        return ProjectRankingSnapshotResponseDTO.builder()
+                .id(snapshotId)
+                .data(List.of(RankingItemDTO.builder()
+                        .projectId(projectId)
+                        .rank(rank)
+                        .givedPumatiCount(givedPumatiCount)
+                        .build()))
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectRankingSnapshotServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectRankingSnapshotServiceImpl.java
@@ -1,0 +1,67 @@
+package com.tebutebu.apiserver.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tebutebu.apiserver.domain.Project;
+import com.tebutebu.apiserver.domain.ProjectRankingSnapshot;
+import com.tebutebu.apiserver.repository.ProjectRankingSnapshotRepository;
+import com.tebutebu.apiserver.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class ProjectRankingSnapshotServiceImpl implements ProjectRankingSnapshotService {
+
+    private final ProjectRankingSnapshotRepository projectRankingSnapshotRepository;
+
+    private final ProjectRepository projectRepository;
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${ranking.snapshot.duration.minutes:5}")
+    private long snapshotDurationMinutes;
+
+    @Override
+    public Long register() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(snapshotDurationMinutes);
+        return projectRankingSnapshotRepository
+                .findTopByRequestedAtAfterOrderByRequestedAtDesc(threshold)
+                .map(ProjectRankingSnapshot::getId)
+                .orElseGet(() -> {
+                    List<Project> projects = projectRepository.findAllForRanking();
+
+                    List<Map<String, Object>> rankingList = new ArrayList<>();
+                    int rank = 1;
+                    for (Project p : projects) {
+                        rankingList.add(Map.of(
+                                "project_id", p.getId(),
+                                "rank", rank++,
+                                "gived_pumati_count", p.getTeam().getGivedPumatiCount()
+                        ));
+                    }
+
+                    String json;
+                    try {
+                        json = objectMapper.writeValueAsString(Map.of("projects", rankingList));
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+
+                    ProjectRankingSnapshot snapshot = ProjectRankingSnapshot.builder()
+                            .rankingData(json)
+                            .requestedAt(LocalDateTime.now())
+                            .build();
+                    return projectRankingSnapshotRepository.save(snapshot).getId();
+                });
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -22,6 +22,8 @@ public interface ProjectService {
 
     CursorPageResponseDTO<ProjectResponseDTO> getRankingPage(CursorPageRequestDTO dto);
 
+    CursorPageResponseDTO<ProjectResponseDTO> getLatestPage(CursorPageRequestDTO dto);
+
     Long register(ProjectCreateRequestDTO dto);
 
     void modify(Long projectId, ProjectUpdateRequestDTO dto);

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -37,6 +37,8 @@ public interface ProjectService {
         return ProjectResponseDTO.builder()
                 .id(project.getId())
                 .teamId(team.getId())
+                .term(team.getTerm())
+                .teamNumber(team.getNumber())
                 .givedPumatiCount(team.getGivedPumatiCount())
                 .receivedPumatiCount(team.getReceivedPumatiCount())
                 .badgeImageUrl(team.getBadgeImageUrl())

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -1,0 +1,56 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.Project;
+import com.tebutebu.apiserver.domain.Team;
+import com.tebutebu.apiserver.dto.project.image.response.ProjectImageResponseDTO;
+import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
+import com.tebutebu.apiserver.dto.project.request.ProjectUpdateRequestDTO;
+import com.tebutebu.apiserver.dto.project.response.ProjectResponseDTO;
+import com.tebutebu.apiserver.dto.tag.response.TagResponseDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional
+public interface ProjectService {
+
+    @Transactional(readOnly = true)
+    ProjectResponseDTO get(Long id);
+
+    Long register(ProjectCreateRequestDTO dto);
+
+    void modify(Long projectId, ProjectUpdateRequestDTO dto);
+
+    void delete(Long projectId);
+
+    Project dtoToEntity(ProjectCreateRequestDTO dto);
+
+    default ProjectResponseDTO entityToDTO(Project project, Team team, List<ProjectImageResponseDTO> images) {
+
+        List<TagResponseDTO> tags = project.getTagContents().stream()
+                .map(content -> TagResponseDTO.builder()
+                        .content(content)
+                        .build())
+                .collect(Collectors.toList());
+
+        return ProjectResponseDTO.builder()
+                .id(project.getId())
+                .teamId(team.getId())
+                .givedPumatiCount(team.getGivedPumatiCount())
+                .receivedPumatiCount(team.getReceivedPumatiCount())
+                .badgeImageUrl(team.getBadgeImageUrl())
+                .title(project.getTitle())
+                .introduction(project.getIntroduction())
+                .detailedDescription(project.getDetailedDescription())
+                .representativeImageUrl(project.getRepresentativeImageUrl())
+                .images(images)
+                .deploymentUrl(project.getDeploymentUrl())
+                .githubUrl(project.getGithubUrl())
+                .tags(tags)
+                .createdAt(project.getCreatedAt())
+                .modifiedAt(project.getModifiedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -7,6 +7,8 @@ import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.project.response.ProjectResponseDTO;
 import com.tebutebu.apiserver.dto.tag.response.TagResponseDTO;
+import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
+import com.tebutebu.apiserver.pagination.dto.response.CursorPageResponseDTO;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -17,6 +19,8 @@ public interface ProjectService {
 
     @Transactional(readOnly = true)
     ProjectResponseDTO get(Long id);
+
+    CursorPageResponseDTO<ProjectResponseDTO> getRankingPage(CursorPageRequestDTO dto);
 
     Long register(ProjectCreateRequestDTO dto);
 

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
@@ -81,6 +81,28 @@ public class ProjectServiceImpl implements ProjectService {
                 .build();
     }
 
+    @Override
+    public CursorPageResponseDTO<ProjectResponseDTO> getLatestPage(CursorPageRequestDTO dto) {
+        CursorPage<Project> page = projectPagingRepository.findByLatestCursor(dto);
+
+        List<ProjectResponseDTO> data = page.items().stream()
+                .map(p -> {
+                    List<ProjectImageResponseDTO> images = p.getImages().stream()
+                            .map(projectImageService::entityToDTO)
+                            .collect(Collectors.toList());
+                    return entityToDTO(p, p.getTeam(), images);
+                })
+                .collect(Collectors.toList());
+
+        return CursorPageResponseDTO.<ProjectResponseDTO>builder()
+                .data(data)
+                .meta(CursorMetaDTO.builder()
+                        .nextCursorId(page.nextCursorId())
+                        .nextCursorTime(page.nextCursorTime())
+                        .hasNext(page.hasNext())
+                        .build())
+                .build();
+    }
 
     @Override
     public Long register(ProjectCreateRequestDTO dto) {

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
@@ -38,8 +38,6 @@ public class ProjectServiceImpl implements ProjectService {
 
     private final TagService tagService;
 
-    private final ProjectRankingSnapshotService snapshotService;
-
     @Override
     public ProjectResponseDTO get(Long id) {
         Project project = projectRepository.findProjectWithTeamAndImagesById(id)
@@ -56,8 +54,9 @@ public class ProjectServiceImpl implements ProjectService {
 
     @Override
     public CursorPageResponseDTO<ProjectResponseDTO> getRankingPage(CursorPageRequestDTO dto) {
-        Long snapshotId = dto.getContextId() != null ? dto.getContextId() : snapshotService.register();
-        dto.setContextId(snapshotId);
+        if (dto.getContextId() == null) {
+            throw new CustomValidationException("contextIdRequired");
+        }
 
         CursorPage<Project> cursorPage = projectPagingRepository.findByRankingCursor(dto);
 
@@ -71,7 +70,7 @@ public class ProjectServiceImpl implements ProjectService {
                 .collect(Collectors.toList());
 
         CursorMetaDTO meta = CursorMetaDTO.builder()
-                .contextId(snapshotId)
+                .contextId(dto.getContextId())
                 .nextCursorId(cursorPage.nextCursorId())
                 .nextCursorTime(cursorPage.nextCursorTime())
                 .hasNext(cursorPage.hasNext())

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
@@ -70,7 +70,6 @@ public class ProjectServiceImpl implements ProjectService {
                 .collect(Collectors.toList());
 
         CursorMetaDTO meta = CursorMetaDTO.builder()
-                .contextId(dto.getContextId())
                 .nextCursorId(cursorPage.nextCursorId())
                 .nextCursorTime(cursorPage.nextCursorTime())
                 .hasNext(cursorPage.hasNext())

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
@@ -1,0 +1,152 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.Project;
+import com.tebutebu.apiserver.domain.ProjectImage;
+import com.tebutebu.apiserver.domain.Tag;
+import com.tebutebu.apiserver.domain.Team;
+import com.tebutebu.apiserver.dto.project.image.request.ProjectImageRequestDTO;
+import com.tebutebu.apiserver.dto.project.image.response.ProjectImageResponseDTO;
+import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
+import com.tebutebu.apiserver.dto.project.request.ProjectUpdateRequestDTO;
+import com.tebutebu.apiserver.dto.project.response.ProjectResponseDTO;
+import com.tebutebu.apiserver.dto.tag.request.TagCreateRequestDTO;
+import com.tebutebu.apiserver.repository.ProjectRepository;
+import com.tebutebu.apiserver.util.exception.CustomValidationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class ProjectServiceImpl implements ProjectService {
+
+    private final ProjectRepository projectRepository;
+
+    private final ProjectImageService projectImageService;
+
+    private final TagService tagService;
+
+    @Override
+    public ProjectResponseDTO get(Long id) {
+        Project project = projectRepository.findProjectWithTeamAndImagesById(id)
+                .orElseThrow(() -> new NoSuchElementException("projectNotFound"));
+
+        Team team = project.getTeam();
+        log.info("team: {}", team);
+        List<ProjectImageResponseDTO> imageDtos = project.getImages().stream()
+                .map(projectImageService::entityToDTO)
+                .collect(Collectors.toList());
+
+        return entityToDTO(project, team, imageDtos);
+    }
+
+    @Override
+    public Long register(ProjectCreateRequestDTO dto) {
+        if (projectRepository.existsByTeamId(dto.getTeamId())) {
+            throw new CustomValidationException("projectAlreadyExists");
+        }
+
+        Project project = projectRepository.save(dtoToEntity(dto));
+
+        List<String> tagContents = dto.getTags().stream()
+                .map(TagCreateRequestDTO::getContent)
+                .distinct()
+                .collect(Collectors.toList());
+
+        List<Tag> tagEntities = tagContents.stream()
+                .map(content -> {
+                    Long tagId = tagService.register(project.getId(), new TagCreateRequestDTO(content));
+                    return Tag.builder().id(tagId).content(content).build();
+                })
+                .collect(Collectors.toList());
+        project.replaceTags(tagEntities);
+
+        project.changeTagContents(tagContents);
+
+        projectRepository.save(project);
+        return project.getId();
+    }
+
+    @Override
+    public void modify(Long projectId, ProjectUpdateRequestDTO dto) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new NoSuchElementException("projectNotFound"));
+
+        project.changeTitle(dto.getTitle());
+        project.changeIntroduction(dto.getIntroduction());
+        project.changeDetailedDescription(dto.getDetailedDescription());
+        project.changeDeploymentUrl(dto.getDeploymentUrl());
+        project.changeGithubUrl(dto.getGithubUrl());
+
+        project.getImages().clear();
+        dto.getImages().forEach(imgDto -> {
+            ProjectImage pi = ProjectImage.builder()
+                    .sequence(imgDto.getSequence())
+                    .url(imgDto.getUrl())
+                    .build();
+            pi.changeProject(project);
+            project.getImages().add(pi);
+        });
+
+        if (!dto.getImages().isEmpty()) {
+            project.changeRepresentativeImageUrl(dto.getImages().getFirst().getUrl());
+        }
+
+        List<String> tagContents = dto.getTags().stream()
+                .map(TagCreateRequestDTO::getContent)
+                .distinct()
+                .collect(Collectors.toList());
+
+        List<Tag> tags = tagContents.stream()
+                .map(content -> {
+                    Long tagId = tagService.register(projectId, new TagCreateRequestDTO(content));
+                    return Tag.builder().id(tagId).content(content).build();
+                })
+                .collect(Collectors.toList());
+        project.replaceTags(tags);
+
+        project.changeTagContents(tagContents);
+        projectRepository.save(project);
+    }
+
+    @Override
+    public void delete(Long projectId) {
+        if (!projectRepository.existsById(projectId)) {
+            throw new NoSuchElementException("projectNotFound");
+        }
+        projectRepository.deleteById(projectId);
+    }
+
+    @Override
+    public Project dtoToEntity(ProjectCreateRequestDTO dto) {
+        Project project = Project.builder()
+                .team(Team.builder().id(dto.getTeamId()).build())
+                .title(dto.getTitle())
+                .introduction(dto.getIntroduction())
+                .detailedDescription(dto.getDetailedDescription())
+                .deploymentUrl(dto.getDeploymentUrl())
+                .githubUrl(dto.getGithubUrl())
+                .build();
+
+        for (ProjectImageRequestDTO img : dto.getImages()) {
+            ProjectImage pi = ProjectImage.builder()
+                    .sequence(img.getSequence())
+                    .url(img.getUrl())
+                    .build();
+            pi.changeProject(project);
+            project.getImages().add(pi);
+        }
+
+        if (!dto.getImages().isEmpty()) {
+            project.changeRepresentativeImageUrl(dto.getImages().getFirst().getUrl());
+        }
+
+        return project;
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/TagService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/TagService.java
@@ -1,0 +1,21 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.Tag;
+import com.tebutebu.apiserver.dto.tag.request.TagCreateRequestDTO;
+import com.tebutebu.apiserver.dto.tag.response.TagResponseDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface TagService {
+
+    Long register(Long projectId, TagCreateRequestDTO dto);
+
+    Tag dtoToEntity(TagCreateRequestDTO dto);
+
+    default TagResponseDTO entityToDTO(Tag tag) {
+        return TagResponseDTO.builder()
+                .content(tag.getContent())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/TagServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/TagServiceImpl.java
@@ -1,0 +1,31 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.Tag;
+import com.tebutebu.apiserver.dto.tag.request.TagCreateRequestDTO;
+import com.tebutebu.apiserver.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class TagServiceImpl implements TagService {
+
+    private final TagRepository tagRepository;
+
+    @Override
+    public Long register(Long projectId, TagCreateRequestDTO dto) {
+        return tagRepository.findByContentIgnoreCase(dto.getContent())
+                .map(Tag::getId)
+                .orElseGet(() -> tagRepository.save(dtoToEntity(dto)).getId());
+    }
+
+    @Override
+    public Tag dtoToEntity(TagCreateRequestDTO dto) {
+        return Tag.builder()
+                .content(dto.getContent())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/TeamService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/TeamService.java
@@ -26,6 +26,9 @@ public interface TeamService {
                 .id(team.getId())
                 .term(team.getTerm())
                 .number(team.getNumber())
+                .givedPumatiCount(team.getGivedPumatiCount())
+                .receivedPumatiCount(team.getReceivedPumatiCount())
+                .badgeImageUrl(team.getBadgeImageUrl())
                 .createdAt(team.getCreatedAt())
                 .modifiedAt(team.getModifiedAt())
                 .build();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,8 @@ spring.jwt.refresh.cookie.name=${jwt.refresh.cookie.name}
 
 frontend.redirect-uri=${frontend.redirect-uri}
 
+ranking.snapshot.duration.minutes=${ranking.snapshot.duration.minutes}
+
 # registration
 spring.security.oauth2.client.registration.kakao.client-name=${kakao.client.name}
 spring.security.oauth2.client.registration.kakao.client-id=${kakao.client.id}


### PR DESCRIPTION
## ⭐ Key Changes

1. **프로젝트 CRUD 기능**
   - `Project`, `ProjectImage`, `Tag`, `ProjectTag` 엔티티 설계 기반 CRUD 메서드(`get`/`register`/`modify`/`delete`) 구현
   - Service, Repository, DTO 계층 분리 및 책임에 따른 역할 구분

2. **Cursor 기반 페이지네이션**
   - `CursorPageFactory` · `CursorPageSpec` 도입하여 최신순/랭킹순 커서 페이징 로직 재사용 가능하도록 추상화
   - `CursorPageRequestDTO`/`CursorPageResponseDTO` 표준화

3. **랭킹 스냅샷 관리**
   - `ProjectRankingSnapshot` 엔티티 및 레포지토리 추가
   - 최근 5분 내 스냅샷 재사용, 없으면 신규 생성 로직 구현
   - 스냅샷 JSON 파싱 후 `RankingItem` DTO 변환

---

## 🖐️ To reviewers

1. **CursorPageFactory** 추상화 방식이 재사용·확장성에 부합하는지 검토
2. **페이지네이션 파라미터 네이밍** (`cursor-id`, `cursor-time`, `page-size`) 일관성 및 문서화 여부 확인
3. **스냅샷 주기 설정** (`application.yml` 환경변수) 및 동시성·중복 생성 방지 로직 점검
4. **API 응답 구조** (`message`/`data`/`meta`) 통일성 및 에러 핸들링 일관성 확인

---

## 📌 issue

- close #9
