### PR TITLE
[#27] Refactor: 리프레시 토큰 쿠키에 SameSite=None 옵션 적용

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.tebutebu.apiserver.dto.member.request.MemberUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.member.response.MemberResponseDTO;
 import com.tebutebu.apiserver.dto.member.response.MemberSignupResponseDTO;
 import com.tebutebu.apiserver.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,9 +41,10 @@ public class MemberController {
     @PostMapping("/social")
     public ResponseEntity<?> registerOAuthUser(
             @Valid @RequestBody MemberOAuthSignupRequestDTO dto,
+            HttpServletRequest request,
             HttpServletResponse response
     ) {
-        MemberSignupResponseDTO data = memberService.registerOAuthUser(dto, response);
+        MemberSignupResponseDTO data = memberService.registerOAuthUser(dto, request, response);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(Map.of(
                         "message", "signupSuccess",

--- a/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
+++ b/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
@@ -39,7 +39,7 @@ public class JWTCheckFilter extends OncePerRequestFilter {
         }
 
         if (request.getMethod().equals("POST")) {
-            if (path.equals("/api/members/social") || path.startsWith("/api/auth/") || path.equals("/api/pre-signed-url") || path.equals("/api/pre-signed-urls")) {
+            if (path.equals("/api/members/social") || path.startsWith("/api/auth/") || path.equals("/api/pre-signed-url") || path.equals("/api/pre-signed-urls") || path.equals("/api/projects/snapshot")) {
                 return true;
             }
         }

--- a/src/main/java/com/tebutebu/apiserver/security/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/tebutebu/apiserver/security/handler/CustomLoginSuccessHandler.java
@@ -4,7 +4,6 @@ import com.tebutebu.apiserver.security.dto.CustomOAuth2User;
 import com.tebutebu.apiserver.service.RefreshTokenService;
 import com.tebutebu.apiserver.util.CookieUtil;
 import com.tebutebu.apiserver.util.JWTUtil;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -52,12 +51,22 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
 
         responseData.put("accessToken", accessToken);
 
-        Cookie refreshCookie = CookieUtil.createHttpOnlyCookie(
-                refreshCookieName,
-                refreshToken,
-                60 * 60 * 60
-        );
-        response.addCookie(refreshCookie);
+        int maxAge = 60 * 60 * 24;
+        if (request.isSecure()) {
+            CookieUtil.addSecureRefreshTokenCookie(
+                    response,
+                    refreshCookieName,
+                    refreshToken,
+                    maxAge
+            );
+        } else {
+            CookieUtil.addRefreshTokenCookie(
+                    response,
+                    refreshCookieName,
+                    refreshToken,
+                    maxAge
+            );
+        }
 
         String redirectUrl = frontendRedirectUri +
                 "?message=loginSuccess" +

--- a/src/main/java/com/tebutebu/apiserver/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/tebutebu/apiserver/security/handler/CustomLogoutHandler.java
@@ -36,7 +36,13 @@ public class CustomLogoutHandler implements LogoutHandler {
             Map<String,Object> claims = JWTUtil.validateToken(refreshToken);
             Long memberId = ((Number) claims.get("id")).longValue();
             refreshTokenService.deleteByMemberId(memberId);
-            CookieUtil.deleteCookie(response, refreshCookieName);
+
+            if (request.isSecure()) {
+                CookieUtil.deleteSecureRefreshTokenCookie(response, refreshCookieName);
+            } else {
+                CookieUtil.deleteRefreshTokenCookie(response, refreshCookieName);
+            }
         });
     }
+
 }

--- a/src/main/java/com/tebutebu/apiserver/service/MemberService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberService.java
@@ -5,6 +5,7 @@ import com.tebutebu.apiserver.dto.member.request.MemberOAuthSignupRequestDTO;
 import com.tebutebu.apiserver.dto.member.request.MemberUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.member.response.MemberResponseDTO;
 import com.tebutebu.apiserver.dto.member.response.MemberSignupResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,7 +18,7 @@ public interface MemberService {
     @Transactional(readOnly = true)
     MemberResponseDTO get(String authorizationHeader);
 
-    MemberSignupResponseDTO registerOAuthUser(MemberOAuthSignupRequestDTO dto, HttpServletResponse response);
+    MemberSignupResponseDTO registerOAuthUser(MemberOAuthSignupRequestDTO dto, HttpServletRequest request, HttpServletResponse response);
 
     void modify(String authorizationHeader, MemberUpdateRequestDTO dto);
 

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectRankingSnapshotServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectRankingSnapshotServiceImpl.java
@@ -42,6 +42,10 @@ public class ProjectRankingSnapshotServiceImpl implements ProjectRankingSnapshot
                     List<Map<String, Object>> rankingList = new ArrayList<>();
                     int rank = 1;
                     for (Project p : projects) {
+                        if (p.getId() == null || p.getTeam() == null || p.getTeam().getGivedPumatiCount() == null) {
+                            continue;
+                        }
+
                         rankingList.add(Map.of(
                                 "project_id", p.getId(),
                                 "rank", rank++,

--- a/src/main/java/com/tebutebu/apiserver/util/CookieUtil.java
+++ b/src/main/java/com/tebutebu/apiserver/util/CookieUtil.java
@@ -1,33 +1,71 @@
 package com.tebutebu.apiserver.util;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 
 public class CookieUtil {
 
-    private CookieUtil() {
+    private CookieUtil() {}
+
+    public static void addRefreshTokenCookie(
+            HttpServletResponse response,
+            String name,
+            String value,
+            int maxAgeSec
+    ) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("None")
+                .path("/")
+                .maxAge(maxAgeSec)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
-    public static Cookie createHttpOnlyCookie(String name, String value, int maxAgeSec) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(maxAgeSec);
-        return cookie;
+    public static void addSecureRefreshTokenCookie(
+            HttpServletResponse response,
+            String name,
+            String value,
+            int maxAgeSec
+    ) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(maxAgeSec)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
-    public static Cookie createSecureHttpOnlyCookie(String name, String value, int maxAgeSec, boolean isSecure) {
-        Cookie cookie = createHttpOnlyCookie(name, value, maxAgeSec);
-        cookie.setSecure(isSecure);
-        return cookie;
+    public static void deleteRefreshTokenCookie(
+            HttpServletResponse response,
+            String name
+    ) {
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .secure(false)
+                .sameSite("None")
+                .path("/")
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
-    public static void deleteCookie(HttpServletResponse response, String name) {
-        Cookie cookie = new Cookie(name, null);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
+    public static void deleteSecureRefreshTokenCookie(
+            HttpServletResponse response,
+            String name
+    ) {
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
 }


### PR DESCRIPTION
## ⭐ Key Changes

1. `CookieUtil`에 `SameSite=None` 기본 설정 추가
2. HTTP/HTTPS 요청에 따라 Secure 여부를 분기하는 `addRefreshTokenCookie` / `addSecureRefreshTokenCookie` 메서드 구현
3. `AuthController#refreshToken` 와 `CustomLogoutHandler` 에서 새로운 `CookieUtil` API로 쿠키 생성 및 삭제 로직 수정

<br />

## 🖐️ To reviewers

1. `SameSite=None` 설정이 다양한 브라우저 환경에서 의도대로 동작하는지 확인 부탁드립니다.
2. Secure / non-secure 분기 로직이 올바르게 적용되었는지 검토해주세요.
3. CORS 설정(`Allow-Credentials: true`)과 연동해 쿠키가 정상 전달되는지 실제 프론트 환경에서 테스트 부탁드립니다.

<br />

## 📌 issue

- close #27
