### PR TITLE
[#41] Feat: 준/받은 품앗이 수 증가 기능

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/TeamController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/TeamController.java
@@ -50,4 +50,20 @@ public class TeamController {
         ));
     }
 
+    @PatchMapping("/{teamId}/gived-pumati")
+    public ResponseEntity<?> increaseGivedPumati(@PathVariable Long teamId) {
+        return ResponseEntity.ok(Map.of(
+                "message", "increaseGivedPumatiSuccess",
+                "data", Map.of("givedPumatiCount", teamService.incrementGivedPumati(teamId))
+        ));
+    }
+
+    @PatchMapping("/{teamId}/received-pumati")
+    public ResponseEntity<?> increaseReceivedPumati(@PathVariable Long teamId) {
+        return ResponseEntity.ok(Map.of(
+                "message", "increaseReceivedPumatiSuccess",
+                "data", Map.of("receivedPumatiCount", teamService.incrementReceivedPumati(teamId))
+        ));
+    }
+
 }

--- a/src/main/java/com/tebutebu/apiserver/domain/Team.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Team.java
@@ -63,4 +63,12 @@ public class Team extends TimeStampedEntity {
     @Column(length = 512)
     private String badgeImageUrl;
 
+    public void increaseGivedPumati() {
+        this.givedPumatiCount++;
+    }
+
+    public void increaseReceivedPumati() {
+        this.receivedPumatiCount++;
+    }
+
 }

--- a/src/main/java/com/tebutebu/apiserver/service/TeamService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/TeamService.java
@@ -19,6 +19,10 @@ public interface TeamService {
 
     Long register(TeamCreateRequestDTO dto);
 
+    Long incrementGivedPumati(Long teamId);
+
+    Long incrementReceivedPumati(Long teamId);
+
     Team dtoToEntity(TeamCreateRequestDTO dto);
 
     default TeamResponseDTO entityToDTO(Team team) {

--- a/src/main/java/com/tebutebu/apiserver/service/TeamServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/TeamServiceImpl.java
@@ -81,6 +81,24 @@ public class TeamServiceImpl implements TeamService {
     }
 
     @Override
+    public Long incrementGivedPumati(Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new NoSuchElementException("teamNotFound"));
+        team.increaseGivedPumati();
+        teamRepository.save(team);
+        return team.getGivedPumatiCount();
+    }
+
+    @Override
+    public Long incrementReceivedPumati(Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new NoSuchElementException("teamNotFound"));
+        team.increaseReceivedPumati();
+        teamRepository.save(team);
+        return team.getReceivedPumatiCount();
+    }
+
+    @Override
     public Team dtoToEntity(TeamCreateRequestDTO dto) {
         return Team.builder()
                 .term(dto.getTerm())


### PR DESCRIPTION
## ⭐ Key Changes

1. **팀 품앗이 수 증가 API (`PATCH`) 구현**
   - `PATCH /api/teams/{teamId}/gived-pumati`: 해당 팀의 `givedPumatiCount`를 1 증가
   - `PATCH /api/teams/{teamId}/received-pumati`: 해당 팀의 `receivedPumatiCount`를 1 증가

2. **Team 도메인 메서드 분리**
   - `increaseGivedPumati()`, `increaseReceivedPumati()` 메서드를 도메인에 추가하여 증가 로직 캡슐화
   - 서비스 계층에서 도메인 메서드 호출로 명확한 책임 분리

3. **불필요한 DB 재조회 제거**
   - 서비스 메서드가 증가된 수치를 직접 반환하도록 하여 컨트롤러에서의 재조회 제거
   - 응답 성능 개선 및 트랜잭션 내 일관성 확보

---

## 🖐️ To reviewers

1. **품앗이 수 증가 흐름 확인**
   - 각 API 호출 시 `givedPumatiCount` 또는 `receivedPumatiCount`가 1씩 정확히 증가하는지
   - 응답에 포함된 수치가 실제 DB 상태와 일치하는지

2. **예외 상황 처리**
   - 존재하지 않는 `teamId`로 요청 시 `teamNotFound` 예외가 발생하는지
   - 동시에 여러 요청이 들어올 경우 동시성 문제가 발생하지 않는지 (필요 시 후속 개선 논의)

---

## 📌 Issue

- close #41
