### PR TITLE
[#41] Feat: 팀 id로 프로젝트 작성 여부 확인 기능

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/TeamController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/TeamController.java
@@ -50,4 +50,20 @@ public class TeamController {
         ));
     }
 
+    @PatchMapping("/{teamId}/gived-pumati")
+    public ResponseEntity<?> increaseGivedPumati(@PathVariable Long teamId) {
+        return ResponseEntity.ok(Map.of(
+                "message", "increaseGivedPumatiSuccess",
+                "data", Map.of("givedPumatiCount", teamService.incrementGivedPumati(teamId))
+        ));
+    }
+
+    @PatchMapping("/{teamId}/received-pumati")
+    public ResponseEntity<?> increaseReceivedPumati(@PathVariable Long teamId) {
+        return ResponseEntity.ok(Map.of(
+                "message", "increaseReceivedPumatiSuccess",
+                "data", Map.of("receivedPumatiCount", teamService.incrementReceivedPumati(teamId))
+        ));
+    }
+
 }

--- a/src/main/java/com/tebutebu/apiserver/controller/TeamController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/TeamController.java
@@ -4,6 +4,7 @@ import com.tebutebu.apiserver.dto.member.response.MemberResponseDTO;
 import com.tebutebu.apiserver.dto.team.request.TeamCreateRequestDTO;
 import com.tebutebu.apiserver.dto.team.response.TeamListResponseDTO;
 import com.tebutebu.apiserver.service.MemberService;
+import com.tebutebu.apiserver.service.ProjectService;
 import com.tebutebu.apiserver.service.TeamService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,17 @@ public class TeamController {
     private final TeamService teamService;
 
     private final MemberService memberService;
+
+    private final ProjectService projectService;
+
+    @GetMapping("/{teamId}/projects/existence")
+    public ResponseEntity<?> checkProjectExistence(@PathVariable Long teamId) {
+        boolean exists = projectService.existsByTeamId(teamId);
+        return ResponseEntity.ok(Map.of(
+                "message", "checkProjectExistenceSuccess",
+                "data", Map.of("exists", exists)
+        ));
+    }
 
     @PostMapping("")
     public ResponseEntity<?> register(@Valid @RequestBody TeamCreateRequestDTO dto) {

--- a/src/main/java/com/tebutebu/apiserver/domain/Team.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Team.java
@@ -63,4 +63,12 @@ public class Team extends TimeStampedEntity {
     @Column(length = 512)
     private String badgeImageUrl;
 
+    public void increaseGivedPumati() {
+        this.givedPumatiCount++;
+    }
+
+    public void increaseReceivedPumati() {
+        this.receivedPumatiCount++;
+    }
+
 }

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -20,6 +20,9 @@ public interface ProjectService {
     @Transactional(readOnly = true)
     ProjectResponseDTO get(Long id);
 
+    @Transactional(readOnly = true)
+    boolean existsByTeamId(Long teamId);
+
     CursorPageResponseDTO<ProjectResponseDTO> getRankingPage(CursorPageRequestDTO dto);
 
     CursorPageResponseDTO<ProjectResponseDTO> getLatestPage(CursorPageRequestDTO dto);

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
@@ -53,6 +53,11 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
+    public boolean existsByTeamId(Long teamId) {
+        return projectRepository.existsByTeamId(teamId);
+    }
+
+    @Override
     public CursorPageResponseDTO<ProjectResponseDTO> getRankingPage(CursorPageRequestDTO dto) {
         if (dto.getContextId() == null) {
             throw new CustomValidationException("contextIdRequired");

--- a/src/main/java/com/tebutebu/apiserver/service/TeamService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/TeamService.java
@@ -19,6 +19,10 @@ public interface TeamService {
 
     Long register(TeamCreateRequestDTO dto);
 
+    Long incrementGivedPumati(Long teamId);
+
+    Long incrementReceivedPumati(Long teamId);
+
     Team dtoToEntity(TeamCreateRequestDTO dto);
 
     default TeamResponseDTO entityToDTO(Team team) {

--- a/src/main/java/com/tebutebu/apiserver/service/TeamServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/TeamServiceImpl.java
@@ -81,6 +81,24 @@ public class TeamServiceImpl implements TeamService {
     }
 
     @Override
+    public Long incrementGivedPumati(Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new NoSuchElementException("teamNotFound"));
+        team.increaseGivedPumati();
+        teamRepository.save(team);
+        return team.getGivedPumatiCount();
+    }
+
+    @Override
+    public Long incrementReceivedPumati(Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new NoSuchElementException("teamNotFound"));
+        team.increaseReceivedPumati();
+        teamRepository.save(team);
+        return team.getReceivedPumatiCount();
+    }
+
+    @Override
     public Team dtoToEntity(TeamCreateRequestDTO dto) {
         return Team.builder()
                 .term(dto.getTerm())


### PR DESCRIPTION
## ⭐ Key Changes

1. **팀 프로젝트 존재 여부 확인 API (`GET /api/teams/{teamId}/projects/existence`) 구현**
   - 특정 팀 ID에 해당하는 프로젝트가 존재하는지 여부를 boolean 값으로 응답
   - `ProjectService.existsByTeamId(teamId)`를 호출하여 DB에서 존재 여부 판별
   - 응답 형태: `{ "exists": true/false }`

<br />

## 🖐️ To reviewers

1. 프로젝트가 없는 경우에도 `200 OK` 응답이 의도대로 잘 반환되는지 확인 부탁드립니다.
2. `/projects/existence` 경로가 RESTful한 구조로 적절한지 의견 있으시면 공유해주세요.
3. 향후 프로젝트 상세 조회나 메타 정보 반환 등 확장을 고려할 때 이 엔드포인트가 충돌 없이 유지될 수 있을지 검토 부탁드립니다.

<br />

## 📌 issue

- close #41
