### PR TITLE
[#41] Feat: 팀 id로 프로젝트 작성 여부 확인 기능

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/AttendanceController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/AttendanceController.java
@@ -1,0 +1,41 @@
+package com.tebutebu.apiserver.controller;
+
+import com.tebutebu.apiserver.dto.attendance.daily.response.AttendanceDailyResponseDTO;
+import com.tebutebu.apiserver.dto.member.response.MemberResponseDTO;
+import com.tebutebu.apiserver.service.AttendanceDailyService;
+import com.tebutebu.apiserver.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@Log4j2
+@RequestMapping("/api/attendances")
+public class AttendanceController {
+
+    private final AttendanceDailyService attendanceDailyService;
+
+    private final MemberService memberService;
+
+    @PostMapping("")
+    public ResponseEntity<?> register(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        MemberResponseDTO memberDTO = memberService.get(authorizationHeader);
+        AttendanceDailyResponseDTO dto = attendanceDailyService.register(memberDTO.getId());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Map.of(
+                        "message", "attendanceSuccess",
+                        "data", dto
+                ));
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/controller/AttendanceController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/AttendanceController.java
@@ -1,17 +1,16 @@
 package com.tebutebu.apiserver.controller;
 
 import com.tebutebu.apiserver.dto.attendance.daily.response.AttendanceDailyResponseDTO;
+import com.tebutebu.apiserver.dto.attendance.weekly.response.AttendanceWeeklyResponseDTO;
 import com.tebutebu.apiserver.dto.member.response.MemberResponseDTO;
 import com.tebutebu.apiserver.service.AttendanceDailyService;
+import com.tebutebu.apiserver.service.AttendanceWeeklyService;
 import com.tebutebu.apiserver.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -22,6 +21,8 @@ import java.util.Map;
 public class AttendanceController {
 
     private final AttendanceDailyService attendanceDailyService;
+
+    private final AttendanceWeeklyService attendanceWeeklyService;
 
     private final MemberService memberService;
 
@@ -36,6 +37,18 @@ public class AttendanceController {
                         "message", "attendanceSuccess",
                         "data", dto
                 ));
+    }
+
+    @GetMapping("")
+    public ResponseEntity<?> getWeeklyStatus(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        MemberResponseDTO member = memberService.get(authorizationHeader);
+        AttendanceWeeklyResponseDTO dto = attendanceWeeklyService.getWeeklyStatus(member.getId());
+        return ResponseEntity.ok(Map.of(
+                "message", "getAttendanceSuccess",
+                "data", dto
+        ));
     }
 
 }

--- a/src/main/java/com/tebutebu/apiserver/domain/AttendanceDaily.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/AttendanceDaily.java
@@ -34,7 +34,7 @@ public class AttendanceDaily extends TimeStampedEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(name = "deve_luck_overall", nullable = false, length = 150)
+    @Column(name = "dev_luck_overall", nullable = false, length = 150)
     private String devLuckOverall;
 
     @Column(name = "checked_at", nullable = false)

--- a/src/main/java/com/tebutebu/apiserver/domain/AttendanceDaily.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/AttendanceDaily.java
@@ -1,0 +1,43 @@
+package com.tebutebu.apiserver.domain;
+
+import com.tebutebu.apiserver.domain.common.TimeStampedEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.FetchType;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString(exclude = {"member"})
+public class AttendanceDaily extends TimeStampedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "deve_luck_overall", nullable = false, length = 150)
+    private String devLuckOverall;
+
+    @Column(name = "checked_at", nullable = false)
+    private LocalDateTime checkedAt;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/domain/AttendanceWeekly.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/AttendanceWeekly.java
@@ -1,0 +1,59 @@
+package com.tebutebu.apiserver.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString(exclude = {"member"})
+public class AttendanceWeekly {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "last_checked_date", nullable = false)
+    private LocalDate lastCheckedDate;
+
+    @Builder.Default
+    @Column(nullable = false, columnDefinition = "SMALLINT UNSIGNED")
+    private int streak = 0;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "summary", columnDefinition = "json", nullable = false)
+    private Map<String, Boolean> summary;
+
+    public void incrementStreak() {
+        this.streak++;
+    }
+
+    public void resetStreak() {
+        this.streak = 0;
+    }
+
+    public void updateLastCheckedDate(LocalDate date) {
+        this.lastCheckedDate = date;
+    }
+
+    public void updateSummary(Map<String, Boolean> summary) {
+        this.summary = summary;
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/attendance/daily/response/AttendanceDailyResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/attendance/daily/response/AttendanceDailyResponseDTO.java
@@ -1,0 +1,21 @@
+package com.tebutebu.apiserver.dto.attendance.daily.response;
+
+import com.tebutebu.apiserver.dto.fortune.response.DevLuckDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AttendanceDailyResponseDTO {
+
+    private Long id;
+
+    private DevLuckDTO devLuckDTO;
+
+    private LocalDateTime checkedAt;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/attendance/weekly/response/AttendanceWeeklyResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/attendance/weekly/response/AttendanceWeeklyResponseDTO.java
@@ -1,0 +1,25 @@
+package com.tebutebu.apiserver.dto.attendance.weekly.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AttendanceWeeklyResponseDTO {
+
+    private boolean today;
+
+    private Map<String, Boolean> weekly;
+
+    private int streak;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate lastCheckedDate;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/fortune/request/FortuneGenerateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/fortune/request/FortuneGenerateRequestDTO.java
@@ -1,0 +1,31 @@
+package com.tebutebu.apiserver.dto.fortune.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.tebutebu.apiserver.domain.Course;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FortuneGenerateRequestDTO {
+
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    @Size(max = 10, message = "이름은 최대 10자까지 가능합니다.")
+    private String name;
+
+    private Course course;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/fortune/response/DevLuckDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/fortune/response/DevLuckDTO.java
@@ -1,0 +1,14 @@
+package com.tebutebu.apiserver.dto.fortune.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DevLuckDTO {
+
+    private String overall;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/fortune/response/FortuneResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/fortune/response/FortuneResponseDTO.java
@@ -1,0 +1,16 @@
+package com.tebutebu.apiserver.dto.fortune.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FortuneResponseDTO {
+
+    private String message;
+
+    private DevLuckDTO data;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/AttendanceDailyRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/AttendanceDailyRepository.java
@@ -1,0 +1,17 @@
+package com.tebutebu.apiserver.repository;
+
+import com.tebutebu.apiserver.domain.AttendanceDaily;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AttendanceDailyRepository extends JpaRepository<AttendanceDaily, Long> {
+
+    List<AttendanceDaily> findByMemberId(Long memberId);
+
+    List<AttendanceDaily> findByMemberIdAndCheckedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+
+    boolean existsByMemberIdAndCheckedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/AttendanceWeeklyRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/AttendanceWeeklyRepository.java
@@ -1,0 +1,12 @@
+package com.tebutebu.apiserver.repository;
+
+import com.tebutebu.apiserver.domain.AttendanceWeekly;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AttendanceWeeklyRepository extends JpaRepository<AttendanceWeekly, Long> {
+
+    Optional<AttendanceWeekly> findByMemberId(Long memberId);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/AttendanceDailyService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/AttendanceDailyService.java
@@ -1,0 +1,27 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.AttendanceDaily;
+import com.tebutebu.apiserver.dto.attendance.daily.response.AttendanceDailyResponseDTO;
+import com.tebutebu.apiserver.dto.fortune.response.DevLuckDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface AttendanceDailyService {
+
+    AttendanceDailyResponseDTO register(Long memberId);
+
+    boolean existsToday(Long memberId);
+
+    AttendanceDaily dtoToEntity(AttendanceDailyResponseDTO dto);
+
+    default AttendanceDailyResponseDTO entityToDTO(AttendanceDaily attendanceDaily) {
+        return AttendanceDailyResponseDTO.builder()
+                .id(attendanceDaily.getId())
+                .devLuckDTO(DevLuckDTO.builder()
+                        .overall(attendanceDaily.getDevLuckOverall())
+                        .build())
+                .checkedAt(attendanceDaily.getCheckedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/AttendanceDailyServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/AttendanceDailyServiceImpl.java
@@ -1,0 +1,88 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.AttendanceDaily;
+import com.tebutebu.apiserver.domain.Member;
+import com.tebutebu.apiserver.dto.attendance.daily.response.AttendanceDailyResponseDTO;
+import com.tebutebu.apiserver.dto.fortune.request.FortuneGenerateRequestDTO;
+import com.tebutebu.apiserver.dto.fortune.response.DevLuckDTO;
+import com.tebutebu.apiserver.dto.member.response.MemberResponseDTO;
+import com.tebutebu.apiserver.repository.AttendanceDailyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.NoSuchElementException;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class AttendanceDailyServiceImpl implements AttendanceDailyService {
+
+    private final AttendanceDailyRepository attendanceDailyRepository;
+
+    private final MemberService memberService;
+
+    private final FortuneService fortuneService;
+
+    @Override
+    public AttendanceDailyResponseDTO register(Long memberId) {
+        if (existsToday(memberId)) {
+            LocalDate today = LocalDate.now();
+            LocalDateTime start = today.atStartOfDay();
+            LocalDateTime end = today.atTime(LocalTime.MAX);
+
+            AttendanceDaily existing = attendanceDailyRepository
+                    .findByMemberIdAndCheckedAtBetween(memberId, start, end)
+                    .stream()
+                    .findFirst()
+                    .orElseThrow();
+
+            return entityToDTO(existing);
+        }
+
+        MemberResponseDTO memberDTO = memberService.get(memberId);
+        if (memberDTO == null) {
+            throw new NoSuchElementException("memberNotFound");
+        }
+
+        FortuneGenerateRequestDTO requestDTO = FortuneGenerateRequestDTO.builder()
+                .name(memberDTO.getName())
+                .course(memberDTO.getCourse())
+                .date(LocalDate.now())
+                .build();
+
+        DevLuckDTO devLuckDTO = fortuneService.getnerateDevLuck(requestDTO);
+
+        AttendanceDaily attendance = AttendanceDaily.builder()
+                .member(Member.builder().id(memberId).build())
+                .checkedAt(LocalDateTime.now())
+                .devLuckOverall(devLuckDTO.getOverall())
+                .build();
+
+        AttendanceDaily saved = attendanceDailyRepository.save(attendance);
+        return entityToDTO(saved);
+    }
+
+    @Override
+    public boolean existsToday(Long memberId) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime start = today.atStartOfDay();
+        LocalDateTime end = today.atTime(LocalTime.MAX);
+        return attendanceDailyRepository.existsByMemberIdAndCheckedAtBetween(
+                memberId, start, end
+        );
+    }
+
+    @Override
+    public AttendanceDaily dtoToEntity(AttendanceDailyResponseDTO dto) {
+        return AttendanceDaily.builder()
+                .id(dto.getId())
+                .devLuckOverall(dto.getDevLuckDTO().getOverall())
+                .checkedAt(dto.getCheckedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/AttendanceDailyServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/AttendanceDailyServiceImpl.java
@@ -27,6 +27,8 @@ public class AttendanceDailyServiceImpl implements AttendanceDailyService {
 
     private final FortuneService fortuneService;
 
+    private final AttendanceWeeklyService attendanceWeeklyService;
+
     @Override
     public AttendanceDailyResponseDTO register(Long memberId) {
         if (existsToday(memberId)) {
@@ -63,6 +65,7 @@ public class AttendanceDailyServiceImpl implements AttendanceDailyService {
                 .build();
 
         AttendanceDaily saved = attendanceDailyRepository.save(attendance);
+        attendanceWeeklyService.recordDailyAttendance(memberId);
         return entityToDTO(saved);
     }
 

--- a/src/main/java/com/tebutebu/apiserver/service/AttendanceWeeklyService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/AttendanceWeeklyService.java
@@ -1,0 +1,35 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.AttendanceWeekly;
+import com.tebutebu.apiserver.dto.attendance.weekly.response.AttendanceWeeklyResponseDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Transactional
+public interface AttendanceWeeklyService {
+
+    @Transactional(readOnly = true)
+    AttendanceWeeklyResponseDTO getWeeklyStatus(Long memberId);
+
+    void recordDailyAttendance(Long memberId);
+
+    default AttendanceWeeklyResponseDTO entityToDTO(AttendanceWeekly attendanceWeekly, boolean isToday, int streak) {
+        Map<String, Boolean> orderedSummary = new LinkedHashMap<>();
+        for (DayOfWeek dow : DayOfWeek.values()) {
+            orderedSummary.put(
+                    dow.name().toLowerCase(),
+                    attendanceWeekly.getSummary().getOrDefault(dow.name().toLowerCase(), false)
+            );
+        }
+        return AttendanceWeeklyResponseDTO.builder()
+                .today(isToday)
+                .weekly(orderedSummary)
+                .streak(streak)
+                .lastCheckedDate(attendanceWeekly.getLastCheckedDate())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/AttendanceWeeklyServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/AttendanceWeeklyServiceImpl.java
@@ -1,0 +1,81 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.AttendanceWeekly;
+import com.tebutebu.apiserver.domain.Member;
+import com.tebutebu.apiserver.dto.attendance.weekly.response.AttendanceWeeklyResponseDTO;
+import com.tebutebu.apiserver.repository.AttendanceWeeklyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class AttendanceWeeklyServiceImpl implements AttendanceWeeklyService {
+
+    private final AttendanceWeeklyRepository attendanceWeeklyRepository;
+
+    @Override
+    public AttendanceWeeklyResponseDTO getWeeklyStatus(Long memberId) {
+        AttendanceWeekly weekly = attendanceWeeklyRepository.findByMemberId(memberId)
+                .orElseGet(() -> createEmptyWeekly(memberId));
+
+        LocalDate today = LocalDate.now();
+        boolean isToday = weekly.getSummary().getOrDefault(
+                today.getDayOfWeek().name().toLowerCase(), false
+        );
+
+        int streak = computeDisplayStreak(weekly, isToday, today);
+        return entityToDTO(weekly, isToday, streak);
+    }
+
+    @Override
+    public void recordDailyAttendance(Long memberId) {
+        LocalDate today = LocalDate.now();
+
+        AttendanceWeekly weekly = attendanceWeeklyRepository.findByMemberId(memberId)
+                .orElseGet(() -> createEmptyWeekly(memberId));
+
+        LocalDate lastDate = weekly.getLastCheckedDate();
+        if (lastDate != null && lastDate.isEqual(today.minusDays(1))) {
+            weekly.incrementStreak();
+        } else {
+            weekly.resetStreak();
+            weekly.incrementStreak();
+        }
+
+        Map<String, Boolean> summary = weekly.getSummary();
+        summary.put(today.getDayOfWeek().name().toLowerCase(), true);
+        weekly.updateSummary(summary);
+        weekly.updateLastCheckedDate(today);
+
+        attendanceWeeklyRepository.save(weekly);
+    }
+
+    private AttendanceWeekly createEmptyWeekly(Long memberId) {
+        Map<String, Boolean> summary = new LinkedHashMap<>();
+        for (DayOfWeek dow : DayOfWeek.values()) {
+            summary.put(dow.name().toLowerCase(), false);
+        }
+        return AttendanceWeekly.builder()
+                .member(Member.builder().id(memberId).build())
+                .lastCheckedDate(null)
+                .streak(0)
+                .summary(summary)
+                .build();
+    }
+
+    private int computeDisplayStreak(AttendanceWeekly weekly, boolean isToday, LocalDate today) {
+        LocalDate lastDate = weekly.getLastCheckedDate();
+        if (lastDate != null && (lastDate.isEqual(today) || lastDate.isEqual(today.minusDays(1)))) {
+            return weekly.getStreak();
+        }
+        return isToday ? 1 : 0;
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/FortuneService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/FortuneService.java
@@ -1,0 +1,10 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.dto.fortune.response.DevLuckDTO;
+import com.tebutebu.apiserver.dto.fortune.request.FortuneGenerateRequestDTO;
+
+public interface FortuneService {
+
+    DevLuckDTO getnerateDevLuck(FortuneGenerateRequestDTO request);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/FortuneServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/FortuneServiceImpl.java
@@ -1,0 +1,38 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.dto.fortune.response.DevLuckDTO;
+import com.tebutebu.apiserver.dto.fortune.request.FortuneGenerateRequestDTO;
+import com.tebutebu.apiserver.dto.fortune.response.FortuneResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class FortuneServiceImpl implements FortuneService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${fortune.service.url}")
+    private String fortuneServiceUrl;
+
+    @Override
+    public DevLuckDTO getnerateDevLuck(FortuneGenerateRequestDTO request) {
+        HttpEntity<FortuneGenerateRequestDTO> httpEntity = new HttpEntity<>(request);
+        ResponseEntity<FortuneResponseDTO> response = restTemplate.postForEntity(
+                fortuneServiceUrl + "/api/llm/fortune",
+                httpEntity,
+                FortuneResponseDTO.class
+        );
+
+        return (response.getBody() != null && response.getBody().getData() != null)
+                ? response.getBody().getData()
+                : DevLuckDTO.builder().build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -35,8 +35,8 @@ public interface ProjectService {
     default ProjectResponseDTO entityToDTO(Project project, Team team, List<ProjectImageResponseDTO> images) {
 
         List<TagResponseDTO> tags = project.getTagContents().stream()
-                .map(content -> TagResponseDTO.builder()
-                        .content(content)
+                .map(tagContentDTO -> TagResponseDTO.builder()
+                        .content(tagContentDTO.getContent())
                         .build())
                 .collect(Collectors.toList());
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,7 @@ spring.jwt.refresh.threshold=${jwt.refresh.threshold}
 spring.jwt.refresh.cookie.name=${jwt.refresh.cookie.name}
 
 frontend.redirect-uri=${frontend.redirect-uri}
+fortune.service.url=${fortune.service.url}
 
 ranking.snapshot.duration.minutes=${ranking.snapshot.duration.minutes}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,7 @@ spring.jwt.refresh.cookie.name=${jwt.refresh.cookie.name}
 
 frontend.redirect-uri=${frontend.redirect-uri}
 fortune.service.url=${fortune.service.url}
+fortune.service.error-message=${fortune.service.error-message}
 
 ranking.snapshot.duration.minutes=${ranking.snapshot.duration.minutes}
 


### PR DESCRIPTION
## ⭐ Key Changes

1. **팀 프로젝트 존재 여부 확인 API (`GET /api/teams/{teamId}/projects/existence`) 구현**
   - 특정 팀 ID에 해당하는 프로젝트가 존재하는지 여부를 boolean 값으로 응답
   - `ProjectService.existsByTeamId(teamId)`를 호출하여 DB에서 존재 여부 판별
   - 응답 형태: `{ "exists": true/false }`

<br />

## 🖐️ To reviewers

1. 프로젝트가 없는 경우에도 `200 OK` 응답이 의도대로 잘 반환되는지 확인 부탁드립니다.
2. `/projects/existence` 경로가 RESTful한 구조로 적절한지 의견 있으시면 공유해주세요.
3. 향후 프로젝트 상세 조회나 메타 정보 반환 등 확장을 고려할 때 이 엔드포인트가 충돌 없이 유지될 수 있을지 검토 부탁드립니다.

<br />

## 📌 issue

- close #41
