### PR TITLE
[#41] Feat: 팀 id로 프로젝트 작성 여부 확인 기능

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.tebutebu.apiserver.dto.member.request.MemberUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.member.response.MemberResponseDTO;
 import com.tebutebu.apiserver.dto.member.response.MemberSignupResponseDTO;
 import com.tebutebu.apiserver.service.MemberService;
+import com.tebutebu.apiserver.service.ProjectService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -24,6 +25,8 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    private final ProjectService projectService;
+
     @GetMapping("/{memberId}")
     public ResponseEntity<?> get(@PathVariable("memberId") Long memberId) {
         MemberResponseDTO dto = memberService.get(memberId);
@@ -36,6 +39,22 @@ public class MemberController {
     ) {
         MemberResponseDTO dto = memberService.get(authorizationHeader);
         return ResponseEntity.ok(Map.of("message", "getMemberSuccess", "data", dto));
+    }
+
+    @GetMapping("/projects/existence")
+    public ResponseEntity<?> checkProjectExistence(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        MemberResponseDTO member = memberService.get(authorizationHeader);
+        Long teamId = member.getTeamId();
+
+        if (teamId == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("message", "teamIdIsNull", "data", false));
+        }
+
+        boolean exists = projectService.existsByTeamId(teamId);
+        return ResponseEntity.ok(Map.of("message", "checkProjectExistenceSuccess", "data", exists));
     }
 
     @PostMapping("/social")

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -20,6 +20,9 @@ public interface ProjectService {
     @Transactional(readOnly = true)
     ProjectResponseDTO get(Long id);
 
+    @Transactional(readOnly = true)
+    boolean existsByTeamId(Long teamId);
+
     CursorPageResponseDTO<ProjectResponseDTO> getRankingPage(CursorPageRequestDTO dto);
 
     CursorPageResponseDTO<ProjectResponseDTO> getLatestPage(CursorPageRequestDTO dto);

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
@@ -53,6 +53,11 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
+    public boolean existsByTeamId(Long teamId) {
+        return projectRepository.existsByTeamId(teamId);
+    }
+
+    @Override
     public CursorPageResponseDTO<ProjectResponseDTO> getRankingPage(CursorPageRequestDTO dto) {
         if (dto.getContextId() == null) {
             throw new CustomValidationException("contextIdRequired");


### PR DESCRIPTION
## ⭐ Key Changes

1. **팀 프로젝트 존재 여부 확인 API (`GET /api/teams/{teamId}/projects/existence`) 구현**
   - 특정 팀 ID에 해당하는 프로젝트가 존재하는지 여부를 boolean 값으로 응답
   - `ProjectService.existsByTeamId(teamId)`를 호출하여 DB에서 존재 여부 판별
   - 응답 형태: `{ "exists": true/false }`

<br />

## 🖐️ To reviewers

1. 프로젝트가 없는 경우에도 `200 OK` 응답이 의도대로 잘 반환되는지 확인 부탁드립니다.
2. `/projects/existence` 경로가 RESTful한 구조로 적절한지 의견 있으시면 공유해주세요.
3. 향후 프로젝트 상세 조회나 메타 정보 반환 등 확장을 고려할 때 이 엔드포인트가 충돌 없이 유지될 수 있을지 검토 부탁드립니다.

<br />

## 📌 issue

- close #41
