### PR TITLE
[#60] Refactor: 프론트엔드가 로컬에서 실행 중일 때만 쿠키 도메인 localhost 설정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/AuthController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/AuthController.java
@@ -24,6 +24,8 @@ public class AuthController {
 
     private final AuthService authService;
 
+    private final CookieUtil cookieUtil;
+
     @PutMapping("/tokens")
     public ResponseEntity<?> refreshToken(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
@@ -34,21 +36,13 @@ public class AuthController {
         TokensDTO tokens = authService.refreshTokens(authorizationHeader, refreshTokenCookie);
 
         int maxAge = 60 * 60 * 24;
-        if (request.isSecure()) {
-            CookieUtil.addSecureRefreshTokenCookie(
-                    response,
-                    refreshCookieName,
-                    tokens.getRefreshToken(),
-                    maxAge
-            );
-        } else {
-            CookieUtil.addRefreshTokenCookie(
-                    response,
-                    refreshCookieName,
-                    tokens.getRefreshToken(),
-                    maxAge
-            );
-        }
+        cookieUtil.addRefreshTokenCookie(
+                response,
+                refreshCookieName,
+                tokens.getRefreshToken(),
+                maxAge,
+                request.isSecure()
+        );
 
         Map<String, Object> body = Map.of(
                 "message", "refreshSuccess",

--- a/src/main/java/com/tebutebu/apiserver/security/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/tebutebu/apiserver/security/handler/CustomLoginSuccessHandler.java
@@ -36,6 +36,8 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
     @Value("${spring.jwt.refresh.cookie.name}")
     private String refreshCookieName;
 
+    private final CookieUtil cookieUtil;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
@@ -52,21 +54,13 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
         responseData.put("accessToken", accessToken);
 
         int maxAge = 60 * 60 * 24;
-        if (request.isSecure()) {
-            CookieUtil.addSecureRefreshTokenCookie(
-                    response,
-                    refreshCookieName,
-                    refreshToken,
-                    maxAge
-            );
-        } else {
-            CookieUtil.addRefreshTokenCookie(
-                    response,
-                    refreshCookieName,
-                    refreshToken,
-                    maxAge
-            );
-        }
+        cookieUtil.addRefreshTokenCookie(
+                response,
+                refreshCookieName,
+                refreshToken,
+                maxAge,
+                request.isSecure()
+        );
 
         String redirectUrl = frontendRedirectUri +
                 "?message=loginSuccess" +

--- a/src/main/java/com/tebutebu/apiserver/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/tebutebu/apiserver/security/handler/CustomLogoutHandler.java
@@ -25,6 +25,8 @@ public class CustomLogoutHandler implements LogoutHandler {
 
     private final RefreshTokenService refreshTokenService;
 
+    private final CookieUtil cookieUtil;
+
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         Optional<Cookie> cookie = Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
@@ -37,11 +39,7 @@ public class CustomLogoutHandler implements LogoutHandler {
             Long memberId = ((Number) claims.get("id")).longValue();
             refreshTokenService.deleteByMemberId(memberId);
 
-            if (request.isSecure()) {
-                CookieUtil.deleteSecureRefreshTokenCookie(response, refreshCookieName);
-            } else {
-                CookieUtil.deleteRefreshTokenCookie(response, refreshCookieName);
-            }
+            cookieUtil.deleteRefreshTokenCookie(response, refreshCookieName, request.isSecure());
         });
     }
 

--- a/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
@@ -51,6 +51,8 @@ public class MemberServiceImpl implements MemberService {
 
     private final RefreshTokenService refreshTokenService;
 
+    private final CookieUtil cookieUtil;
+
     @Override
     public MemberResponseDTO get(Long memberId) {
         Member member = memberRepository.findByIdWithTeam(memberId)
@@ -101,21 +103,13 @@ public class MemberServiceImpl implements MemberService {
         refreshTokenService.persistRefreshToken(member.getId(), refreshToken);
 
         int maxAge = 60 * 60 * 24;
-        if (request.isSecure()) {
-            CookieUtil.addSecureRefreshTokenCookie(
-                    response,
-                    refreshCookieName,
-                    refreshToken,
-                    maxAge
-            );
-        } else {
-            CookieUtil.addRefreshTokenCookie(
-                    response,
-                    refreshCookieName,
-                    refreshToken,
-                    maxAge
-            );
-        }
+        cookieUtil.addRefreshTokenCookie(
+                response,
+                refreshCookieName,
+                refreshToken,
+                maxAge,
+                request.isSecure()
+        );
 
         OAuthCreateRequestDTO oauthDto = OAuthCreateRequestDTO.builder()
                 .memberId(member.getId())

--- a/src/main/java/com/tebutebu/apiserver/util/CookieUtil.java
+++ b/src/main/java/com/tebutebu/apiserver/util/CookieUtil.java
@@ -1,70 +1,58 @@
 package com.tebutebu.apiserver.util;
 
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 public class CookieUtil {
 
-    private CookieUtil() {}
+    @Value("${frontend.is-local:false}")
+    private boolean isFrontendLocal;
 
-    public static void addRefreshTokenCookie(
+    public void addRefreshTokenCookie(
             HttpServletResponse response,
             String name,
             String value,
-            int maxAgeSec
+            int maxAgeSec,
+            boolean secure
     ) {
-        ResponseCookie cookie = ResponseCookie.from(name, value)
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
                 .httpOnly(true)
-                .secure(false)
+                .secure(secure)
                 .sameSite("None")
                 .path("/")
-                .maxAge(maxAgeSec)
-                .build();
+                .maxAge(maxAgeSec);
+
+        if (isFrontendLocal) {
+            builder.domain("localhost");
+        }
+
+        ResponseCookie cookie = builder.build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
-    public static void addSecureRefreshTokenCookie(
+    public void deleteRefreshTokenCookie(
             HttpServletResponse response,
             String name,
-            String value,
-            int maxAgeSec
+            boolean secure
     ) {
-        ResponseCookie cookie = ResponseCookie.from(name, value)
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, "")
                 .httpOnly(true)
-                .secure(true)
+                .secure(secure)
                 .sameSite("None")
                 .path("/")
-                .maxAge(maxAgeSec)
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-    }
+                .maxAge(0);
 
-    public static void deleteRefreshTokenCookie(
-            HttpServletResponse response,
-            String name
-    ) {
-        ResponseCookie cookie = ResponseCookie.from(name, "")
-                .httpOnly(true)
-                .secure(false)
-                .sameSite("None")
-                .path("/")
-                .maxAge(0)
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-    }
+        if (isFrontendLocal) {
+            builder.domain("localhost");
+        }
 
-    public static void deleteSecureRefreshTokenCookie(
-            HttpServletResponse response,
-            String name
-    ) {
-        ResponseCookie cookie = ResponseCookie.from(name, "")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .path("/")
-                .maxAge(0)
-                .build();
+        ResponseCookie cookie = builder.build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,7 @@ spring.jwt.refresh-token.expiration=${jwt.refresh.token.expiration}
 spring.jwt.refresh.threshold=${jwt.refresh.threshold}
 spring.jwt.refresh.cookie.name=${jwt.refresh.cookie.name}
 
+frontend.is-local=${frontend.is-local}
 frontend.redirect-uri=${frontend.redirect-uri}
 fortune.service.url=${fortune.service.url}
 fortune.service.error-message=${fortune.service.error-message}


### PR DESCRIPTION
## ⭐ Key Changes

1. `frontend.is-local` 환경 변수 도입 (`application.properties`)
2. `CookieUtil`에서 로컬 여부에 따라 쿠키 도메인 조건 분기 처리
3. 운영 환경에서는 `.domain()` 생략 → 요청 도메인 자동 귀속

<br />

## 🖐️ To reviewers

1. Safari 등 일부 브라우저에서는 `.domain("localhost")` 설정 시 동작하지 않을 수 있으므로, 생략 여부에 대해 더 나은 아이디어 있으시면 제안해주세요.

<br />

## 📌 issue

- close #60
