### PR TITLE
[#62] Fix: Fortune API 요청 시 body 누락 문제 해결

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/service/FortuneServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/FortuneServiceImpl.java
@@ -1,13 +1,14 @@
 package com.tebutebu.apiserver.service;
 
-import com.tebutebu.apiserver.dto.fortune.response.DevLuckDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.tebutebu.apiserver.dto.fortune.request.FortuneGenerateRequestDTO;
+import com.tebutebu.apiserver.dto.fortune.response.DevLuckDTO;
 import com.tebutebu.apiserver.dto.fortune.response.FortuneResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -20,8 +21,8 @@ public class FortuneServiceImpl implements FortuneService {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
-    @Value("${fortune.service.url}")
-    private String fortuneServiceUrl;
+    @Value("${fortune.service.uri}")
+    private String fortuneServiceUri;
 
     @Value("${fortune.service.error-message}")
     private String fortuneServiceErrorMessage;
@@ -29,9 +30,18 @@ public class FortuneServiceImpl implements FortuneService {
     @Override
     public DevLuckDTO getnerateDevLuck(FortuneGenerateRequestDTO request) {
         try {
-            HttpEntity<FortuneGenerateRequestDTO> httpEntity = new HttpEntity<>(request);
-            ResponseEntity<FortuneResponseDTO> response = restTemplate.postForEntity(
-                    fortuneServiceUrl + "/api/llm/fortune",
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JavaTimeModule());
+            String jsonBody = mapper.writeValueAsString(request);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            HttpEntity<String> httpEntity = new HttpEntity<>(jsonBody, headers);
+
+            ResponseEntity<FortuneResponseDTO> response = restTemplate.exchange(
+                    fortuneServiceUri,
+                    HttpMethod.POST,
                     httpEntity,
                     FortuneResponseDTO.class
             );

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,7 +22,7 @@ spring.jwt.refresh.cookie.name=${jwt.refresh.cookie.name}
 
 frontend.is-local=${frontend.is-local}
 frontend.redirect-uri=${frontend.redirect-uri}
-fortune.service.url=${fortune.service.url}
+fortune.service.uri=${fortune.service.uri}
 fortune.service.error-message=${fortune.service.error-message}
 
 ranking.snapshot.duration.minutes=${ranking.snapshot.duration.minutes}


### PR DESCRIPTION
## ⭐ Key Changes

1. `RestTemplate.postForEntity()` → `exchange()` 방식으로 전환하여 요청 전송 명확화
2. `ObjectMapper`를 활용해 DTO를 JSON 문자열로 직접 직렬화
3. `HttpEntity<String>` 사용 + `Content-Type: application/json` 명시로 FastAPI가 요청 body를 정상적으로 수신할 수 있도록 수정

<br />

## 🖐️ To reviewers

1. FastAPI에서 발생하던 422 오류의 근본 원인이 body 누락인지 확인 부탁드립니다.
2. 수동 직렬화 방식이 향후 다른 외부 API 연동 시에도 적용 가능한 구조인지 검토해주시면 감사하겠습니다.

<br />

## 📌 issue

- close #62
