### PR TITLE
[#66] Refactor: 회원가입 시 기본 프로필 이미지 URL 저장

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
@@ -41,6 +41,9 @@ public class MemberServiceImpl implements MemberService {
     @Value("${spring.jwt.refresh-token.expiration}")
     private int refreshTokenExpiration;
 
+    @Value("${default.profile.image.url}")
+    private String defaultProfileImageUrl;
+
     private final MemberRepository memberRepository;
 
     private final PasswordEncoder passwordEncoder;
@@ -188,7 +191,7 @@ public class MemberServiceImpl implements MemberService {
                 .name(dto.getName())
                 .nickname(dto.getNickname())
                 .course(dto.getCourse())
-                .profileImageUrl(dto.getProfileImageUrl())
+                .profileImageUrl(dto.getProfileImageUrl() == null ? defaultProfileImageUrl : dto.getProfileImageUrl())
                 .role(dto.getRole())
                 .build();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,6 +29,8 @@ fortune.service.error-message=${fortune.service.error-message}
 
 ranking.snapshot.duration.minutes=${ranking.snapshot.duration.minutes}
 
+default.profile.image.url=${default.profile.image.url}
+
 # registration
 spring.security.oauth2.client.registration.kakao.client-name=${kakao.client.name}
 spring.security.oauth2.client.registration.kakao.client-id=${kakao.client.id}


### PR DESCRIPTION
## ⭐ Key Changes

1. 회원가입 시 `null`이 아닌 **기본 프로필 이미지 URL**을 명시적으로 저장하도록 로직 수정
2. 프론트엔드(Next.js)에서 `img.src`에 `null`이 전달될 경우 발생하는 **깜빡임(flickering)** 현상 방지

<br />

## 🖐️ To reviewers

1. 기본 프로필 이미지 URL을 저장하는 방식(상수, 환경변수 등)이 적절한지 확인 부탁드립니다.
2. 기존 프로필 이미지 수정 기능과의 동작 충돌 여부도 함께 점검해 주세요.

<br />

## 📌 issue

- close #66
