### PR TITLE
[#68] Refactor: 프로젝트 존재 여부 확인 API 엔드포인트 및 응답 구조 수정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
@@ -41,7 +41,7 @@ public class MemberController {
         return ResponseEntity.ok(Map.of("message", "getMemberSuccess", "data", dto));
     }
 
-    @GetMapping("/projects/existence")
+    @GetMapping("/teams/projects/existence")
     public ResponseEntity<?> checkProjectExistence(
             @RequestHeader("Authorization") String authorizationHeader
     ) {
@@ -50,11 +50,11 @@ public class MemberController {
 
         if (teamId == null) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("message", "teamIdIsNull", "data", false));
+                    .body(Map.of("message", "onlyTraineeAllowed"));
         }
 
         boolean exists = projectService.existsByTeamId(teamId);
-        return ResponseEntity.ok(Map.of("message", "checkProjectExistenceSuccess", "data", exists));
+        return ResponseEntity.ok(Map.of("message", "checkProjectExistenceSuccess", "data", Map.of("exists", exists)));
     }
 
     @PostMapping("/social")


### PR DESCRIPTION
## ⭐ Key Changes

1. 기존 `/api/members/projects/existence` 엔드포인트를 `/api/members/teams/projects/existence`로 변경
2. 교육생이 아닌 경우(teamId가 null인 경우) 반환하는 에러 메시지를 `onlyTraineeAllowed`로 수정
3. 응답 필드를 `data: true` → `data: { "exists": true/false }` 형태로 구조화하여 명확성 향상

<br />

## 🖐️ To reviewers

1. 기존 응답을 사용하던 로직이 있다면 영향 범위를 확인 부탁드립니다.

<br />

## 📌 issue

- close #68 
