### PR TITLE
[#45] Feat: 프로젝트 페이지네이션 전용 DTO 도입 및 단일 조회 응답에 순위(teamRank) 필드 추가

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -2,6 +2,7 @@ package com.tebutebu.apiserver.controller;
 
 import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectUpdateRequestDTO;
+import com.tebutebu.apiserver.dto.project.response.ProjectPageResponseDTO;
 import com.tebutebu.apiserver.dto.project.response.ProjectResponseDTO;
 import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
 import com.tebutebu.apiserver.pagination.dto.response.CursorPageResponseDTO;
@@ -58,7 +59,7 @@ public class ProjectController {
                 .cursorTime(null)
                 .pageSize(pageSize)
                 .build();
-        CursorPageResponseDTO<ProjectResponseDTO> page = projectService.getRankingPage(dto);
+        CursorPageResponseDTO<ProjectPageResponseDTO> page = projectService.getRankingPage(dto);
         return ResponseEntity.ok(Map.of(
                 "message", "getRankingPageSuccess",
                 "data", page.getData(),
@@ -78,7 +79,7 @@ public class ProjectController {
                 .cursorTime(cursorTime)
                 .pageSize(pageSize)
                 .build();
-        CursorPageResponseDTO<ProjectResponseDTO> page = projectService.getLatestPage(dto);
+        CursorPageResponseDTO<ProjectPageResponseDTO> page = projectService.getLatestPage(dto);
         return ResponseEntity.ok(Map.of(
                 "message", "getLatestPageSuccess",
                 "data", page.getData(),

--- a/src/main/java/com/tebutebu/apiserver/dto/project/response/ProjectPageResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/project/response/ProjectPageResponseDTO.java
@@ -1,6 +1,5 @@
 package com.tebutebu.apiserver.dto.project.response;
 
-import com.tebutebu.apiserver.dto.project.image.response.ProjectImageResponseDTO;
 import com.tebutebu.apiserver.dto.tag.response.TagResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,13 +11,11 @@ import java.util.List;
 @Getter
 @Builder
 @AllArgsConstructor
-public class ProjectResponseDTO {
+public class ProjectPageResponseDTO {
 
     private Long id;
 
     private Long teamId;
-
-    private Integer teamRank;
 
     private Integer term;
 
@@ -28,15 +25,7 @@ public class ProjectResponseDTO {
 
     private String introduction;
 
-    private String detailedDescription;
-
     private String representativeImageUrl;
-
-    private List<ProjectImageResponseDTO> images;
-
-    private String deploymentUrl;
-
-    private String githubUrl;
 
     private List<TagResponseDTO> tags;
 

--- a/src/main/java/com/tebutebu/apiserver/dto/snapshot/response/RankingItemDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/snapshot/response/RankingItemDTO.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
 
 @Getter
 @Builder
+@Jacksonized
 @AllArgsConstructor
 public class RankingItemDTO {
 

--- a/src/main/java/com/tebutebu/apiserver/repository/ProjectRankingSnapshotRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/ProjectRankingSnapshotRepository.java
@@ -10,4 +10,6 @@ public interface ProjectRankingSnapshotRepository extends JpaRepository<ProjectR
 
     Optional<ProjectRankingSnapshot> findTopByRequestedAtAfterOrderByRequestedAtDesc(LocalDateTime time);
 
+    Optional<ProjectRankingSnapshot> findTopByOrderByRequestedAtDesc();
+
 }

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectRankingSnapshotService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectRankingSnapshotService.java
@@ -1,24 +1,39 @@
 package com.tebutebu.apiserver.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tebutebu.apiserver.domain.ProjectRankingSnapshot;
 import com.tebutebu.apiserver.dto.snapshot.response.ProjectRankingSnapshotResponseDTO;
 import com.tebutebu.apiserver.dto.snapshot.response.RankingItemDTO;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Transactional
 public interface ProjectRankingSnapshotService {
 
     Long register();
 
-    default ProjectRankingSnapshotResponseDTO entityToDTO(Long snapshotId, Long projectId, Integer rank, Long givedPumatiCount) {
+    ProjectRankingSnapshotResponseDTO getLatestSnapshot();
+
+    default ProjectRankingSnapshotResponseDTO entityToDTO(ProjectRankingSnapshot snapshot) {
+        List<RankingItemDTO> items;
+        try {
+            Map<String, List<RankingItemDTO>> wrapper = new ObjectMapper()
+                    .readValue(
+                            snapshot.getRankingData(),
+                            new TypeReference<>() {
+                            }
+                    );
+            items = wrapper.get("projects");
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
+
         return ProjectRankingSnapshotResponseDTO.builder()
-                .id(snapshotId)
-                .data(List.of(RankingItemDTO.builder()
-                        .projectId(projectId)
-                        .rank(rank)
-                        .givedPumatiCount(givedPumatiCount)
-                        .build()))
+                .id(snapshot.getId())
+                .data(items)
                 .build();
     }
 

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectRankingSnapshotServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectRankingSnapshotServiceImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tebutebu.apiserver.domain.Project;
 import com.tebutebu.apiserver.domain.ProjectRankingSnapshot;
+import com.tebutebu.apiserver.dto.snapshot.response.ProjectRankingSnapshotResponseDTO;
 import com.tebutebu.apiserver.repository.ProjectRankingSnapshotRepository;
 import com.tebutebu.apiserver.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 @Service
 @Log4j2
@@ -43,6 +45,14 @@ public class ProjectRankingSnapshotServiceImpl implements ProjectRankingSnapshot
                     return createAndSaveSnapshot();
                 })
                 .orElseGet(this::createAndSaveSnapshot);
+    }
+
+    @Override
+    public ProjectRankingSnapshotResponseDTO getLatestSnapshot() {
+        ProjectRankingSnapshot snapshot = projectRankingSnapshotRepository
+                .findTopByOrderByRequestedAtDesc()
+                .orElseThrow(() -> new NoSuchElementException("snapshotNotFound"));
+        return entityToDTO(snapshot);
     }
 
     private Long createAndSaveSnapshot() {

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -5,6 +5,7 @@ import com.tebutebu.apiserver.domain.Team;
 import com.tebutebu.apiserver.dto.project.image.response.ProjectImageResponseDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectUpdateRequestDTO;
+import com.tebutebu.apiserver.dto.project.response.ProjectPageResponseDTO;
 import com.tebutebu.apiserver.dto.project.response.ProjectResponseDTO;
 import com.tebutebu.apiserver.dto.tag.response.TagResponseDTO;
 import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
@@ -23,9 +24,9 @@ public interface ProjectService {
     @Transactional(readOnly = true)
     boolean existsByTeamId(Long teamId);
 
-    CursorPageResponseDTO<ProjectResponseDTO> getRankingPage(CursorPageRequestDTO dto);
+    CursorPageResponseDTO<ProjectPageResponseDTO> getRankingPage(CursorPageRequestDTO dto);
 
-    CursorPageResponseDTO<ProjectResponseDTO> getLatestPage(CursorPageRequestDTO dto);
+    CursorPageResponseDTO<ProjectPageResponseDTO> getLatestPage(CursorPageRequestDTO dto);
 
     Long register(ProjectCreateRequestDTO dto);
 
@@ -35,17 +36,11 @@ public interface ProjectService {
 
     Project dtoToEntity(ProjectCreateRequestDTO dto);
 
-    default ProjectResponseDTO entityToDTO(Project project, Team team, List<ProjectImageResponseDTO> images) {
-
-        List<TagResponseDTO> tags = project.getTagContents().stream()
-                .map(tagContentDTO -> TagResponseDTO.builder()
-                        .content(tagContentDTO.getContent())
-                        .build())
-                .collect(Collectors.toList());
-
+    default ProjectResponseDTO entityToDTO(Project project, Team team, List<ProjectImageResponseDTO> images, List<TagResponseDTO> tags, Integer teamRank) {
         return ProjectResponseDTO.builder()
                 .id(project.getId())
                 .teamId(team.getId())
+                .teamRank(teamRank)
                 .term(team.getTerm())
                 .teamNumber(team.getNumber())
                 .givedPumatiCount(team.getGivedPumatiCount())

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
@@ -8,8 +8,12 @@ import com.tebutebu.apiserver.dto.project.image.request.ProjectImageRequestDTO;
 import com.tebutebu.apiserver.dto.project.image.response.ProjectImageResponseDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectUpdateRequestDTO;
+import com.tebutebu.apiserver.dto.project.response.ProjectPageResponseDTO;
 import com.tebutebu.apiserver.dto.project.response.ProjectResponseDTO;
+import com.tebutebu.apiserver.dto.snapshot.response.ProjectRankingSnapshotResponseDTO;
+import com.tebutebu.apiserver.dto.snapshot.response.RankingItemDTO;
 import com.tebutebu.apiserver.dto.tag.request.TagCreateRequestDTO;
+import com.tebutebu.apiserver.dto.tag.response.TagResponseDTO;
 import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
 import com.tebutebu.apiserver.pagination.dto.response.CursorMetaDTO;
 import com.tebutebu.apiserver.pagination.dto.response.CursorPageResponseDTO;
@@ -38,18 +42,32 @@ public class ProjectServiceImpl implements ProjectService {
 
     private final TagService tagService;
 
+    private final ProjectRankingSnapshotService projectRankingSnapshotService;
+
     @Override
     public ProjectResponseDTO get(Long id) {
         Project project = projectRepository.findProjectWithTeamAndImagesById(id)
                 .orElseThrow(() -> new NoSuchElementException("projectNotFound"));
 
         Team team = project.getTeam();
-        log.info("team: {}", team);
-        List<ProjectImageResponseDTO> imageDtos = project.getImages().stream()
+        List<ProjectImageResponseDTO> images = project.getImages().stream()
                 .map(projectImageService::entityToDTO)
                 .collect(Collectors.toList());
 
-        return entityToDTO(project, team, imageDtos);
+        List<TagResponseDTO> tags = project.getTagContents().stream()
+                .map(tagContentDTO -> TagResponseDTO.builder()
+                        .content(tagContentDTO.getContent())
+                        .build())
+                .toList();
+
+        ProjectRankingSnapshotResponseDTO snapshot = projectRankingSnapshotService.getLatestSnapshot();
+        Integer teamRank = snapshot.getData().stream()
+                .filter(item -> id.equals(item.getProjectId()))
+                .findFirst()
+                .map(RankingItemDTO::getRank)
+                .orElse(null);
+
+        return entityToDTO(project, team, images, tags, teamRank);
     }
 
     @Override
@@ -58,20 +76,15 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
-    public CursorPageResponseDTO<ProjectResponseDTO> getRankingPage(CursorPageRequestDTO dto) {
+    public CursorPageResponseDTO<ProjectPageResponseDTO> getRankingPage(CursorPageRequestDTO dto) {
         if (dto.getContextId() == null) {
             throw new CustomValidationException("contextIdRequired");
         }
 
         CursorPage<Project> cursorPage = projectPagingRepository.findByRankingCursor(dto);
 
-        List<ProjectResponseDTO> data = cursorPage.items().stream()
-                .map(p -> {
-                    List<ProjectImageResponseDTO> images = p.getImages().stream()
-                            .map(projectImageService::entityToDTO)
-                            .collect(Collectors.toList());
-                    return entityToDTO(p, p.getTeam(), images);
-                })
+        List<ProjectPageResponseDTO> data = cursorPage.items().stream()
+                .map(this::entityToPageDTO)
                 .collect(Collectors.toList());
 
         CursorMetaDTO meta = CursorMetaDTO.builder()
@@ -80,26 +93,21 @@ public class ProjectServiceImpl implements ProjectService {
                 .hasNext(cursorPage.hasNext())
                 .build();
 
-        return CursorPageResponseDTO.<ProjectResponseDTO>builder()
+        return CursorPageResponseDTO.<ProjectPageResponseDTO>builder()
                 .data(data)
                 .meta(meta)
                 .build();
     }
 
     @Override
-    public CursorPageResponseDTO<ProjectResponseDTO> getLatestPage(CursorPageRequestDTO dto) {
+    public CursorPageResponseDTO<ProjectPageResponseDTO> getLatestPage(CursorPageRequestDTO dto) {
         CursorPage<Project> page = projectPagingRepository.findByLatestCursor(dto);
 
-        List<ProjectResponseDTO> data = page.items().stream()
-                .map(p -> {
-                    List<ProjectImageResponseDTO> images = p.getImages().stream()
-                            .map(projectImageService::entityToDTO)
-                            .collect(Collectors.toList());
-                    return entityToDTO(p, p.getTeam(), images);
-                })
+        List<ProjectPageResponseDTO> data = page.items().stream()
+                .map(this::entityToPageDTO)
                 .collect(Collectors.toList());
 
-        return CursorPageResponseDTO.<ProjectResponseDTO>builder()
+        return CursorPageResponseDTO.<ProjectPageResponseDTO>builder()
                 .data(data)
                 .meta(CursorMetaDTO.builder()
                         .nextCursorId(page.nextCursorId())
@@ -211,6 +219,30 @@ public class ProjectServiceImpl implements ProjectService {
         }
 
         return project;
+    }
+
+    private ProjectPageResponseDTO entityToPageDTO(Project project) {
+        Team team = project.getTeam();
+        List<TagResponseDTO> tags = project.getTagContents().stream()
+                .map(tagContentDTO -> TagResponseDTO.builder()
+                        .content(tagContentDTO.getContent())
+                        .build())
+                .toList();
+        return ProjectPageResponseDTO.builder()
+                .id(project.getId())
+                .teamId(team.getId())
+                .term(team.getTerm())
+                .teamNumber(team.getNumber())
+                .givedPumatiCount(team.getGivedPumatiCount())
+                .receivedPumatiCount(team.getReceivedPumatiCount())
+                .badgeImageUrl(team.getBadgeImageUrl())
+                .title(project.getTitle())
+                .introduction(project.getIntroduction())
+                .representativeImageUrl(project.getRepresentativeImageUrl())
+                .tags(tags)
+                .createdAt(project.getCreatedAt())
+                .modifiedAt(project.getModifiedAt())
+                .build();
     }
 
 }


### PR DESCRIPTION
## ⭐ Key Changes

1. **페이지네이션 전용 DTO 도입**
   - `ProjectPageResponseDTO`를 새로 추가하여 목록 조회용 응답을 경량화
   - 태그·이미지·상세 정보는 단일 조회에서만 포함하도록 응답 필드 분리

2. **단일 조회 응답 개선**
   - `ProjectResponseDTO`에 `teamRank` 필드 추가
   - `ProjectService.get(id)` 호출 시 최신 스냅샷에서 랭크를 조회하여 DTO에 포함

3. **서비스 레이어 리팩토링**
   - `entityToPageDTO` 메서드로 `entityToDTO`와 책임 분리
   - 불필요한 필드 매핑 제거 및 빌더 호출 간소화

4. **연관 메서드·시그니처 변경**
   - `ProjectService` 인터페이스에 `getLatestSnapshot()` 활용 로직 반영
   - 컨트롤러 및 테스트 코드에서 DTO 타입 변경

<br />

## 🖐️ To reviewers

1. **DTO 변경 사항**이 API 스펙 문서와 일치하는지 확인해주세요.  
2. **단일 조회 로직**에서 `teamRank`가 올바르게 매핑되는지 검증 부탁드립니다.  
3. **목록 조회**시 `ProjectPageResponseDTO`로 경량화된 응답이 정상 동작하는지 살펴봐 주세요.  

<br />

## 📌 issue

- close #45
