### PR TITLE
[#71] Refactor: 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/MemberController.java
@@ -82,9 +82,11 @@ public class MemberController {
 
     @DeleteMapping("/me")
     public ResponseEntity<?> delete(
-            @RequestHeader("Authorization") String authorizationHeader
+            @RequestHeader("Authorization") String authorizationHeader,
+            HttpServletRequest request,
+            HttpServletResponse response
     ) {
-        memberService.delete(authorizationHeader);
+        memberService.delete(authorizationHeader, request, response);
         return ResponseEntity.ok(Map.of("message", "memberDeleted"));
     }
 

--- a/src/main/java/com/tebutebu/apiserver/domain/Member.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Member.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -18,6 +20,8 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.util.List;
 
 @Entity
 @Builder
@@ -76,6 +80,12 @@ public class Member extends TimeStampedEntity {
 
     @Builder.Default
     private MemberState state = MemberState.ACTIVE;
+
+    @OneToMany(mappedBy="member", cascade=CascadeType.ALL, orphanRemoval=true)
+    private List<AttendanceDaily> attendancesDaily;
+
+    @OneToMany(mappedBy="member", cascade=CascadeType.ALL, orphanRemoval=true)
+    private List<AttendanceWeekly> attendancesWeekly;
 
     public void changeCourse(Course course) {
         this.course = course;

--- a/src/main/java/com/tebutebu/apiserver/service/MemberService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberService.java
@@ -27,7 +27,7 @@ public interface MemberService {
 
     void modify(String authorizationHeader, MemberUpdateRequestDTO dto);
 
-    void delete(String authorizationHeader);
+    void delete(String authorizationHeader, HttpServletRequest request, HttpServletResponse response);
 
     Member dtoToEntity(MemberOAuthSignupRequestDTO dto, String email);
 

--- a/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
@@ -155,7 +155,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public void delete(String authorizationHeader) {
+    public void delete(String authorizationHeader, HttpServletRequest request, HttpServletResponse response) {
         Long memberId = extractMemberIdFromHeader(authorizationHeader);
 
         refreshTokenService.deleteByMemberId(memberId);
@@ -164,6 +164,13 @@ public class MemberServiceImpl implements MemberService {
         if (!memberRepository.existsById(memberId)) {
             throw new CustomValidationException("memberNotFound");
         }
+
+        refreshTokenService.deleteByMemberId(memberId);
+        cookieUtil.deleteRefreshTokenCookie(
+                response,
+                refreshCookieName,
+                request.isSecure()
+        );
 
         memberRepository.deleteById(memberId);
     }


### PR DESCRIPTION
- 회원 탈퇴 시 연관된 출석 데이터 삭제
- 회원의 리프레시 토큰도 함께 삭제되도록 로직 보완

## ⭐ Key Changes

1. `Member` 엔티티에 출석 도메인 연관관계 필드 추가
   - `List<AttendanceDaily> attendancesDaily`
   - `List<AttendanceWeekly> attendancesWeekly`
   - `cascade = CascadeType.ALL`, `orphanRemoval = true` 설정
2. 회원 탈퇴 시 출석 데이터 자동 삭제되도록 JPA 설정
3. `RefreshTokenService` 연동으로 회원 탈퇴 시 토큰 제거 처리 추가

<br />

## 🖐️ To reviewers

1. Member 삭제 시 연관된 Attendance 데이터가 제대로 제거되는지 확인 부탁드립니다.
2.기존 로직과의 충돌 여부나 사이드 이펙트가 있는지도 함께 봐주시면 감사하겠습니다.

<br />

## 📌 issue

- close #71
