### PR TITLE
[#74] Fix: 스냅샷 기반 프로젝트 페이지네이션에서 간헐적으로 발생하던 deadlock 문제 해결

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -13,7 +13,6 @@ import com.tebutebu.apiserver.pagination.dto.response.CursorPageResponseDTO;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Transactional
 public interface ProjectService {
@@ -24,8 +23,10 @@ public interface ProjectService {
     @Transactional(readOnly = true)
     boolean existsByTeamId(Long teamId);
 
+    @Transactional(readOnly = true)
     CursorPageResponseDTO<ProjectPageResponseDTO> getRankingPage(CursorPageRequestDTO dto);
 
+    @Transactional(readOnly = true)
     CursorPageResponseDTO<ProjectPageResponseDTO> getLatestPage(CursorPageRequestDTO dto);
 
     Long register(ProjectCreateRequestDTO dto);


### PR DESCRIPTION
## ⭐ Key Changes

1. **스냅샷 기반 페이지네이션 트랜잭션 최적화**
   - `ProjectServiceImpl#getRankingPage`에 `@Transactional(readOnly = true)`를 적용
   - Hibernate의 불필요한 쓰기 락 시도를 방지하여 deadlock 발생 가능성 제거

2. **간헐적으로 발생하던 deadlock 문제 해결**
   - `projectRepository.findAllById()` 호출 이후 lazy-loading 과정에서 교착 상태가 발생하던 문제 해결
   - 현재까지 동일 문제 재현되지 않음을 확인함

<br />

## 🖐️ To reviewers

1. **readOnly 트랜잭션 적용이 적절한 위치에만 반영되었는지** 확인 부탁드립니다.
2. 해당 변경으로 인해 **프로젝트 랭킹 페이지네이션 응답이 정상 동작하는지** 테스트 확인 바랍니다.
3. **서비스 호출 시 연관 엔티티 로딩 동작이 바뀌는 부작용**이 없는지 유의해주세요.

<br />

## 📌 issue

- close #74
