### PR TITLE
[#73] Feat: 댓글 도메인 관련 API

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/CommentController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/CommentController.java
@@ -1,0 +1,46 @@
+package com.tebutebu.apiserver.controller;
+
+import com.tebutebu.apiserver.dto.comment.request.CommentUpdateRequestDTO;
+import com.tebutebu.apiserver.service.CommentService;
+import com.tebutebu.apiserver.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@Log4j2
+@RequestMapping("/api/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    private final MemberService memberService;
+
+    @GetMapping("/{commentId}")
+    public ResponseEntity<?> get(@PathVariable("commentId") Long commentId) {
+        return ResponseEntity.ok(Map.of("message", "getCommentSuccess", "data", commentService.get(commentId)));
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<?> modify(
+            @PathVariable("commentId") Long commentId,
+            @RequestHeader("Authorization") String authorizationHeader,
+            @Valid @RequestBody CommentUpdateRequestDTO dto
+    ) {
+        Long memberId = memberService.get(authorizationHeader).getId();
+        commentService.modify(commentId, memberId, dto);
+        return ResponseEntity.ok(Map.of("message", "modifyCommentSuccess"));
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<?> remove(@PathVariable("commentId") Long commentId) {
+        commentService.remove(commentId);
+        return ResponseEntity.ok(Map.of("message", "commentDeleted"));
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/controller/CommentController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/CommentController.java
@@ -43,4 +43,19 @@ public class CommentController {
         return ResponseEntity.ok(Map.of("message", "commentDeleted"));
     }
 
+    @PutMapping("/ai/{commentId}")
+    public ResponseEntity<?> modifyAiComment(
+            @PathVariable Long commentId,
+            @RequestBody @Valid CommentUpdateRequestDTO dto
+    ) {
+        commentService.modifyAiComment(commentId, dto.getContent());
+        return ResponseEntity.ok(Map.of("message", "modifyAiCommentSuccess"));
+    }
+
+    @DeleteMapping("/ai/{commentId}")
+    public ResponseEntity<?> deleteAiComment(@PathVariable Long commentId) {
+        commentService.removeAiComment(commentId);
+        return ResponseEntity.ok(Map.of("message", "commentDeleted"));
+    }
+
 }

--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -1,11 +1,14 @@
 package com.tebutebu.apiserver.controller;
 
+import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.project.response.ProjectPageResponseDTO;
 import com.tebutebu.apiserver.dto.project.response.ProjectResponseDTO;
 import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
 import com.tebutebu.apiserver.pagination.dto.response.CursorPageResponseDTO;
+import com.tebutebu.apiserver.service.CommentService;
+import com.tebutebu.apiserver.service.MemberService;
 import com.tebutebu.apiserver.service.ProjectRankingSnapshotService;
 import com.tebutebu.apiserver.service.ProjectService;
 import jakarta.validation.Valid;
@@ -33,6 +36,10 @@ public class ProjectController {
     private final ProjectService projectService;
 
     private final ProjectRankingSnapshotService projectRankingSnapshotService;
+
+    private final MemberService memberService;
+
+    private final CommentService commentService;
 
     @GetMapping("/{projectId}")
     public ResponseEntity<?> get(@PathVariable long projectId) {
@@ -110,6 +117,20 @@ public class ProjectController {
     public ResponseEntity<?> delete(@PathVariable long projectId) {
         projectService.delete(projectId);
         return ResponseEntity.ok(Map.of("message", "projectDeleted"));
+    }
+
+    @PostMapping("/{projectId}/comments")
+    public ResponseEntity<?> registerComment(
+            @PathVariable("projectId") Long projectId,
+            @RequestHeader("Authorization") String authorizationHeader,
+            @Valid @RequestBody CommentCreateRequestDTO dto
+    ) {
+        Long memberId = memberService.get(authorizationHeader).getId();
+        Long commentId = commentService.register(projectId, memberId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "message", "registerSuccess",
+                "data", Map.of("id", commentId)
+        ));
     }
 
 }

--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -1,6 +1,7 @@
 package com.tebutebu.apiserver.controller;
 
 import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
+import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.project.response.ProjectPageResponseDTO;
@@ -89,6 +90,28 @@ public class ProjectController {
         CursorPageResponseDTO<ProjectPageResponseDTO> page = projectService.getLatestPage(dto);
         return ResponseEntity.ok(Map.of(
                 "message", "getLatestPageSuccess",
+                "data", page.getData(),
+                "meta", page.getMeta()
+        ));
+    }
+
+    @GetMapping("/{projectId}/comments")
+    public ResponseEntity<?> scrollComments(
+            @PathVariable("projectId") Long projectId,
+            @RequestParam(name = "cursor-id", defaultValue = "0") @PositiveOrZero Long cursorId,
+            @RequestParam(name = "cursor-time", defaultValue = "#{T(java.time.LocalDateTime).now().format(T(java.time.format.DateTimeFormatter).ISO_DATE_TIME)}")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorTime,
+            @RequestParam(name = "page-size", defaultValue = "10") @Positive @Min(1) @Max(100) Integer pageSize
+    ) {
+        CursorPageRequestDTO dto = CursorPageRequestDTO.builder()
+                .cursorId(cursorId)
+                .cursorTime(cursorTime)
+                .pageSize(pageSize)
+                .build();
+
+        CursorPageResponseDTO<CommentResponseDTO> page = commentService.getLatestCommentsByProject(projectId, dto);
+        return ResponseEntity.ok(Map.of(
+                "message", "getCommentPageSuccess",
                 "data", page.getData(),
                 "meta", page.getMeta()
         ));

--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -1,6 +1,6 @@
 package com.tebutebu.apiserver.controller;
 
-import com.tebutebu.apiserver.dto.comment.request.AiCommentCreateRequestDTO;
+import com.tebutebu.apiserver.dto.comment.ai.request.AiCommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;

--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -1,5 +1,6 @@
 package com.tebutebu.apiserver.controller;
 
+import com.tebutebu.apiserver.dto.comment.request.AiCommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
 import com.tebutebu.apiserver.dto.project.request.ProjectCreateRequestDTO;
@@ -150,6 +151,18 @@ public class ProjectController {
     ) {
         Long memberId = memberService.get(authorizationHeader).getId();
         Long commentId = commentService.register(projectId, memberId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "message", "registerSuccess",
+                "data", Map.of("id", commentId)
+        ));
+    }
+
+    @PostMapping("/{projectId}/comments/ai")
+    public ResponseEntity<?> registerAiComment(
+            @PathVariable Long projectId,
+            @Valid @RequestBody AiCommentCreateRequestDTO dto
+    ) {
+        Long commentId = commentService.registerAiComment(projectId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
                 "message", "registerSuccess",
                 "data", Map.of("id", commentId)

--- a/src/main/java/com/tebutebu/apiserver/domain/Comment.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Comment.java
@@ -1,0 +1,43 @@
+package com.tebutebu.apiserver.domain;
+
+import com.tebutebu.apiserver.domain.common.TimeStampedEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString(exclude = {"member", "project"})
+public class Comment extends TimeStampedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    private CommentType type;
+
+    @NotBlank(message = "댓글 내용은 필수 입력 값입니다.")
+    @Column(nullable = false, length = 300)
+    private String content;
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/domain/CommentType.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/CommentType.java
@@ -1,0 +1,7 @@
+package com.tebutebu.apiserver.domain;
+
+public enum CommentType {
+
+    USER, AI
+
+}

--- a/src/main/java/com/tebutebu/apiserver/domain/Member.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Member.java
@@ -82,6 +82,9 @@ public class Member extends TimeStampedEntity {
     private MemberState state = MemberState.ACTIVE;
 
     @OneToMany(mappedBy="member", cascade=CascadeType.ALL, orphanRemoval=true)
+    private List<Comment> comments;
+
+    @OneToMany(mappedBy="member", cascade=CascadeType.ALL, orphanRemoval=true)
     private List<AttendanceDaily> attendancesDaily;
 
     @OneToMany(mappedBy="member", cascade=CascadeType.ALL, orphanRemoval=true)

--- a/src/main/java/com/tebutebu/apiserver/domain/converter/CommentTypeConverter.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/converter/CommentTypeConverter.java
@@ -1,0 +1,11 @@
+package com.tebutebu.apiserver.domain.converter;
+
+import com.tebutebu.apiserver.domain.CommentType;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class CommentTypeConverter extends BaseEnumConverter<CommentType> {
+    public CommentTypeConverter() {
+        super(CommentType.class);
+    }
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/ai/request/AiCommentCreateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/ai/request/AiCommentCreateRequestDTO.java
@@ -1,4 +1,4 @@
-package com.tebutebu.apiserver.dto.comment.request;
+package com.tebutebu.apiserver.dto.comment.ai.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/ai/request/AiCommentGenerateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/ai/request/AiCommentGenerateRequestDTO.java
@@ -1,0 +1,20 @@
+package com.tebutebu.apiserver.dto.comment.ai.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiCommentGenerateRequestDTO {
+
+    private String commentType;
+
+    private ProjectSummaryDTO projectSummary;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/ai/request/ProjectSummaryDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/ai/request/ProjectSummaryDTO.java
@@ -1,0 +1,32 @@
+package com.tebutebu.apiserver.dto.comment.ai.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectSummaryDTO {
+
+    private String title;
+
+    private String introduction;
+
+    private String detailedDescription;
+
+    private String deploymentUrl;
+
+    private String githubUrl;
+
+    private List<String> tags;
+
+    private Long teamId;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/ai/response/AiCommentGenerateResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/ai/response/AiCommentGenerateResponseDTO.java
@@ -1,0 +1,20 @@
+package com.tebutebu.apiserver.dto.comment.ai.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Map;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@ToString
+public class AiCommentGenerateResponseDTO {
+
+    private String message;
+
+    private Map<String, String> data;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/request/AiCommentCreateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/request/AiCommentCreateRequestDTO.java
@@ -1,0 +1,28 @@
+package com.tebutebu.apiserver.dto.comment.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiCommentCreateRequestDTO {
+
+    @NotBlank(message = "댓글 내용은 필수 입력 값입니다.")
+    @Size(max = 300, message = "댓글 내용은 최대 300자까지 가능합니다.")
+    private String content;
+
+    @NotBlank(message = "작성자 이름은 필수 입력 값입니다.")
+    private String authorName;
+
+    @NotBlank(message = "작성자 닉네임은 필수 입력 값입니다.")
+    private String authorNickname;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/request/CommentCreateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/request/CommentCreateRequestDTO.java
@@ -1,0 +1,22 @@
+package com.tebutebu.apiserver.dto.comment.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentCreateRequestDTO {
+
+    @NotBlank(message = "댓글 내용은 필수 입력 값입니다.")
+    @Size(max = 300, message = "댓글 내용은 최대 300자까지 가능합니다.")
+    String content;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/request/CommentUpdateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/request/CommentUpdateRequestDTO.java
@@ -1,0 +1,22 @@
+package com.tebutebu.apiserver.dto.comment.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentUpdateRequestDTO {
+
+    @NotBlank(message = "댓글 내용은 필수 입력 값입니다.")
+    @Size(max = 300, message = "댓글 내용은 최대 300자까지 가능합니다.")
+    String content;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/response/AuthorDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/response/AuthorDTO.java
@@ -1,0 +1,23 @@
+package com.tebutebu.apiserver.dto.comment.response;
+
+import com.tebutebu.apiserver.domain.Course;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AuthorDTO {
+
+    private Long id;
+    
+    private String name;
+
+    private String nickname;
+
+    private Course course;
+
+    private String profileImageUrl;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/response/CommentResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/response/CommentResponseDTO.java
@@ -1,0 +1,27 @@
+package com.tebutebu.apiserver.dto.comment.response;
+
+import com.tebutebu.apiserver.domain.CommentType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CommentResponseDTO {
+
+    private Long id;
+
+    private Long projectId;
+
+    private CommentType type;
+
+    private String content;
+
+    private AuthorDTO author;
+
+    private LocalDateTime createdAt, modifiedAt;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/dto/member/request/AiMemberSignupRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/member/request/AiMemberSignupRequestDTO.java
@@ -1,0 +1,26 @@
+package com.tebutebu.apiserver.dto.member.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiMemberSignupRequestDTO {
+
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    @Size(max = 10, message = "이름은 최대 10자까지 가능합니다.")
+    private String name;
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    @Size(max = 50, message = "닉네임은 최대 50자까지 가능합니다.")
+    private String nickname;
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/CommentRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/CommentRepository.java
@@ -1,0 +1,18 @@
+package com.tebutebu.apiserver.repository;
+
+import com.tebutebu.apiserver.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c FROM Comment c " +
+            "JOIN FETCH c.project " +
+            "JOIN FETCH c.member " +
+            "WHERE c.id = :id")
+    Optional<Comment> findByIdWithMemberAndProject(@Param("id") Long id);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/paging/comment/CommentPagingRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/paging/comment/CommentPagingRepository.java
@@ -1,0 +1,11 @@
+package com.tebutebu.apiserver.repository.paging.comment;
+
+import com.tebutebu.apiserver.domain.Comment;
+import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
+import com.tebutebu.apiserver.pagination.internal.CursorPage;
+
+public interface CommentPagingRepository {
+
+    CursorPage<Comment> findByProjectLatestCursor(Long projectId, CursorPageRequestDTO req);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/paging/comment/CommentPagingRepositoryImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/paging/comment/CommentPagingRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.tebutebu.apiserver.repository.paging.comment;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.tebutebu.apiserver.domain.Comment;
+import com.tebutebu.apiserver.domain.QComment;
+import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
+import com.tebutebu.apiserver.pagination.factory.CursorPageFactory;
+import com.tebutebu.apiserver.pagination.factory.CursorPageSpec;
+import com.tebutebu.apiserver.pagination.internal.CursorPage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentPagingRepositoryImpl implements CommentPagingRepository {
+
+    private final CursorPageFactory cursorPageFactory;
+
+    private final QComment c = QComment.comment;
+
+    @Override
+    public CursorPage<Comment> findByProjectLatestCursor(Long projectId, CursorPageRequestDTO req) {
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(c.project.id.eq(projectId));
+
+        OrderSpecifier<?>[] orderBy = new OrderSpecifier[]{
+                c.createdAt.desc(),
+                c.id.desc()
+        };
+
+        CursorPageSpec<Comment> spec = CursorPageSpec.<Comment>builder()
+                .entityPath(c)
+                .where(where)
+                .orderBy(orderBy)
+                .createdAtExpr(c.createdAt)
+                .idExpr(c.id)
+                .cursorId(req.getCursorId())
+                .cursorTime(req.getCursorTime())
+                .pageSize(req.getPageSize())
+                .build();
+        return cursorPageFactory.create(spec);
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
+++ b/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
@@ -33,7 +33,8 @@ public class JWTCheckFilter extends OncePerRequestFilter {
         }
 
         if (request.getMethod().equals("GET")) {
-            if (path.equals("/") || path.equals("/docs") || path.startsWith("/api/oauth/") || path.startsWith("/api/teams") || path.startsWith("/api/projects")) {
+            if (path.equals("/") || path.equals("/docs") || path.startsWith("/api/oauth/")
+                    || path.startsWith("/api/teams") || path.startsWith("/api/projects") || path.startsWith("/api/comments")) {
                 return true;
             }
         }

--- a/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
+++ b/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
@@ -40,7 +40,9 @@ public class JWTCheckFilter extends OncePerRequestFilter {
         }
 
         if (request.getMethod().equals("POST")) {
-            if (path.equals("/api/members/social") || path.startsWith("/api/auth/") || path.equals("/api/pre-signed-url") || path.equals("/api/pre-signed-urls") || path.equals("/api/projects/snapshot")) {
+            if (path.equals("/api/members/social") || path.startsWith("/api/auth/")
+                    || path.equals("/api/pre-signed-url") || path.equals("/api/pre-signed-urls")
+                    || path.equals("/api/projects/snapshot") || path.endsWith("/ai")) {
                 return true;
             }
         }

--- a/src/main/java/com/tebutebu/apiserver/service/AiCommentRequestService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/AiCommentRequestService.java
@@ -1,0 +1,12 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.dto.comment.ai.request.AiCommentGenerateRequestDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface AiCommentRequestService {
+
+    @Transactional(readOnly = true)
+    void requestAiComment(Long projectId, AiCommentGenerateRequestDTO request);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/AiCommentRequestServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/AiCommentRequestServiceImpl.java
@@ -2,9 +2,8 @@ package com.tebutebu.apiserver.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.tebutebu.apiserver.dto.fortune.request.FortuneGenerateRequestDTO;
-import com.tebutebu.apiserver.dto.fortune.response.DevLuckDTO;
-import com.tebutebu.apiserver.dto.fortune.response.FortuneResponseDTO;
+import com.tebutebu.apiserver.dto.comment.ai.request.AiCommentGenerateRequestDTO;
+import com.tebutebu.apiserver.dto.comment.ai.response.AiCommentGenerateResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,20 +16,17 @@ import java.util.Objects;
 @Service
 @Log4j2
 @RequiredArgsConstructor
-public class FortuneServiceImpl implements FortuneService {
+public class AiCommentRequestServiceImpl implements AiCommentRequestService {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
-    @Value("${fortune.service.uri}")
-    private String fortuneServiceUri;
-
-    @Value("${fortune.service.error-message}")
-    private String fortuneServiceErrorMessage;
+    @Value("${ai.comment.service.url}")
+    private String aiCommentServiceUrl;
 
     private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
     @Override
-    public DevLuckDTO getnerateDevLuck(FortuneGenerateRequestDTO request) {
+    public void requestAiComment(Long projectId, AiCommentGenerateRequestDTO request) {
         try {
             String jsonBody = mapper.writeValueAsString(request);
 
@@ -39,25 +35,22 @@ public class FortuneServiceImpl implements FortuneService {
 
             HttpEntity<String> httpEntity = new HttpEntity<>(jsonBody, headers);
 
-            ResponseEntity<FortuneResponseDTO> response = restTemplate.exchange(
-                    fortuneServiceUri,
+            ResponseEntity<AiCommentGenerateResponseDTO> response = restTemplate.exchange(
+                    aiCommentServiceUrl + "/api/projects/" + projectId + "/comments",
                     HttpMethod.POST,
                     httpEntity,
-                    FortuneResponseDTO.class
+                    AiCommentGenerateResponseDTO.class
             );
 
             if (response.getStatusCode().is2xxSuccessful() && Objects.requireNonNull(response.getBody()).getData() != null) {
-                return response.getBody().getData();
+                log.info(response.getBody());
             } else {
-                log.warn("Fortune service returned non-200 status: {}, body: {}",
-                        response.getStatusCode(), response.getBody());
+                log.warn("AI comment server responded with non-2xx: {}, body: {}", response.getStatusCode(), response.getBody());
             }
 
         } catch (Exception e) {
-            log.warn("Error occurred while calling fortune service: {}", e.getMessage());
+            log.warn("Error calling AI comment service: {}", e.getMessage());
         }
-
-        return DevLuckDTO.builder().overall(fortuneServiceErrorMessage).build();
     }
 
 }

--- a/src/main/java/com/tebutebu/apiserver/service/CommentService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.tebutebu.apiserver.service;
 
 import com.tebutebu.apiserver.domain.Comment;
+import com.tebutebu.apiserver.dto.comment.request.AiCommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
@@ -22,6 +23,12 @@ public interface CommentService {
     void modify(Long commentId, Long memberId, CommentUpdateRequestDTO dto);
 
     void remove(Long commentId);
+
+    Long registerAiComment(Long projectId, AiCommentCreateRequestDTO dto);
+
+    void modifyAiComment(Long commentId, String content);
+
+    void removeAiComment(Long commentId);
 
     Comment dtoToEntity(Long projectId, Long memberId, CommentCreateRequestDTO dto);
 

--- a/src/main/java/com/tebutebu/apiserver/service/CommentService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/CommentService.java
@@ -4,6 +4,8 @@ import com.tebutebu.apiserver.domain.Comment;
 import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
+import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
+import com.tebutebu.apiserver.pagination.dto.response.CursorPageResponseDTO;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -11,6 +13,9 @@ public interface CommentService {
 
     @Transactional(readOnly = true)
     CommentResponseDTO get(Long commentId);
+
+    @Transactional(readOnly = true)
+    CursorPageResponseDTO<CommentResponseDTO> getLatestCommentsByProject(Long projectId, CursorPageRequestDTO dto);
 
     Long register(Long projectId, Long memberId, CommentCreateRequestDTO dto);
 

--- a/src/main/java/com/tebutebu/apiserver/service/CommentService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/CommentService.java
@@ -1,7 +1,7 @@
 package com.tebutebu.apiserver.service;
 
 import com.tebutebu.apiserver.domain.Comment;
-import com.tebutebu.apiserver.dto.comment.request.AiCommentCreateRequestDTO;
+import com.tebutebu.apiserver.dto.comment.ai.request.AiCommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;

--- a/src/main/java/com/tebutebu/apiserver/service/CommentService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/CommentService.java
@@ -1,0 +1,32 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.Comment;
+import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
+import com.tebutebu.apiserver.dto.comment.request.CommentUpdateRequestDTO;
+import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface CommentService {
+
+    @Transactional(readOnly = true)
+    CommentResponseDTO get(Long commentId);
+
+    Long register(Long projectId, Long memberId, CommentCreateRequestDTO dto);
+
+    void modify(Long commentId, Long memberId, CommentUpdateRequestDTO dto);
+
+    void remove(Long commentId);
+
+    Comment dtoToEntity(Long projectId, Long memberId, CommentCreateRequestDTO dto);
+
+    default CommentResponseDTO entityToDTO(Comment comment) {
+        return CommentResponseDTO.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .modifiedAt(comment.getModifiedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/CommentServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/CommentServiceImpl.java
@@ -1,0 +1,93 @@
+package com.tebutebu.apiserver.service;
+
+import com.tebutebu.apiserver.domain.Comment;
+import com.tebutebu.apiserver.domain.CommentType;
+import com.tebutebu.apiserver.domain.Member;
+import com.tebutebu.apiserver.domain.Project;
+import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
+import com.tebutebu.apiserver.dto.comment.request.CommentUpdateRequestDTO;
+import com.tebutebu.apiserver.dto.comment.response.AuthorDTO;
+import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
+import com.tebutebu.apiserver.repository.CommentRepository;
+import com.tebutebu.apiserver.util.exception.CustomValidationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    public CommentResponseDTO get(Long commentId) {
+        Comment comment = commentRepository.findByIdWithMemberAndProject(commentId)
+                .orElseThrow(() -> new NoSuchElementException("commentNotFound"));
+
+        if (comment.getProject() == null) {
+            throw new NoSuchElementException("projectNotFound");
+        }
+        return entityToDTO(comment);
+    }
+
+    @Override
+    public Long register(Long projectId, Long memberId, CommentCreateRequestDTO dto) {
+        Comment comment = dtoToEntity(projectId, memberId, dto);
+        return commentRepository.save(comment).getId();
+    }
+
+    @Override
+    public void modify(Long commentId, Long memberId, CommentUpdateRequestDTO dto) {
+        Comment comment = commentRepository.findByIdWithMemberAndProject(commentId)
+                .orElseThrow(() -> new NoSuchElementException("commentNotFound"));
+
+        if (!comment.getMember().getId().equals(memberId)) {
+            throw new CustomValidationException("notCommentAuthor");
+        }
+
+        comment.changeContent(dto.getContent());
+        commentRepository.save(comment);
+    }
+
+    @Override
+    public void remove(Long commentId) {
+        if (!commentRepository.existsById(commentId)) {
+            throw new NoSuchElementException("commentNotFound");
+        }
+        commentRepository.deleteById(commentId);
+    }
+
+    @Override
+    public Comment dtoToEntity(Long projectId, Long memberId, CommentCreateRequestDTO dto) {
+        return Comment.builder()
+                .member(Member.builder().id(memberId).build())
+                .project(Project.builder().id(projectId).build())
+                .type(CommentType.USER)
+                .content(dto.getContent())
+                .build();
+    }
+
+    @Override
+    public CommentResponseDTO entityToDTO(Comment comment) {
+        return CommentResponseDTO.builder()
+                .id(comment.getId())
+                .projectId(comment.getProject().getId())
+                .type(comment.getType())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .modifiedAt(comment.getModifiedAt())
+                .author(AuthorDTO.builder()
+                        .id(comment.getMember().getId())
+                        .name(comment.getMember().getName())
+                        .nickname(comment.getMember().getNickname())
+                        .course(comment.getMember().getCourse())
+                        .profileImageUrl(comment.getMember().getProfileImageUrl())
+                        .build())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/CommentServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/CommentServiceImpl.java
@@ -4,7 +4,7 @@ import com.tebutebu.apiserver.domain.Comment;
 import com.tebutebu.apiserver.domain.CommentType;
 import com.tebutebu.apiserver.domain.Member;
 import com.tebutebu.apiserver.domain.Project;
-import com.tebutebu.apiserver.dto.comment.request.AiCommentCreateRequestDTO;
+import com.tebutebu.apiserver.dto.comment.ai.request.AiCommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.response.AuthorDTO;
@@ -19,7 +19,6 @@ import com.tebutebu.apiserver.repository.paging.comment.CommentPagingRepository;
 import com.tebutebu.apiserver.util.exception.CustomValidationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -29,9 +28,6 @@ import java.util.NoSuchElementException;
 @Log4j2
 @RequiredArgsConstructor
 public class CommentServiceImpl implements CommentService {
-
-    @Value("${default.profile.image.url}")
-    private String defaultProfileImageUrl;
 
     private final CommentRepository commentRepository;
 

--- a/src/main/java/com/tebutebu/apiserver/service/MemberService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.tebutebu.apiserver.service;
 
 import com.tebutebu.apiserver.domain.Member;
+import com.tebutebu.apiserver.dto.member.request.AiMemberSignupRequestDTO;
 import com.tebutebu.apiserver.dto.member.request.MemberOAuthSignupRequestDTO;
 import com.tebutebu.apiserver.dto.member.request.MemberUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.member.response.MemberResponseDTO;
@@ -24,6 +25,8 @@ public interface MemberService {
     List<MemberResponseDTO> getMembersByTeamId(Long teamId);
 
     MemberSignupResponseDTO registerOAuthUser(MemberOAuthSignupRequestDTO dto, HttpServletRequest request, HttpServletResponse response);
+
+    Long registerAiMember(AiMemberSignupRequestDTO dto);
 
     void modify(String authorizationHeader, MemberUpdateRequestDTO dto);
 

--- a/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
@@ -2,7 +2,10 @@ package com.tebutebu.apiserver.service;
 
 import com.github.javafaker.Faker;
 import com.tebutebu.apiserver.domain.Member;
+import com.tebutebu.apiserver.domain.MemberRole;
+import com.tebutebu.apiserver.domain.MemberState;
 import com.tebutebu.apiserver.domain.Team;
+import com.tebutebu.apiserver.dto.member.request.AiMemberSignupRequestDTO;
 import com.tebutebu.apiserver.dto.member.request.MemberOAuthSignupRequestDTO;
 import com.tebutebu.apiserver.dto.member.request.MemberUpdateRequestDTO;
 import com.tebutebu.apiserver.dto.member.response.MemberResponseDTO;
@@ -25,6 +28,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -134,6 +138,23 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public Long registerAiMember(AiMemberSignupRequestDTO dto) {
+        String email = generateUniqueAiEmail();
+
+        Member member = Member.builder()
+                .email(email)
+                .password(passwordEncoder.encode("!A1ai-comment"))
+                .name(dto.getName())
+                .nickname(dto.getNickname())
+                .profileImageUrl(defaultProfileImageUrl)
+                .isSocial(false)
+                .role(MemberRole.USER)
+                .state(MemberState.ACTIVE)
+                .build();
+        return memberRepository.save(member).getId();
+    }
+
+    @Override
     public void modify(String authorizationHeader, MemberUpdateRequestDTO dto) {
         Long memberId = extractMemberIdFromHeader(authorizationHeader);
         Member member = memberRepository.findById(memberId)
@@ -201,6 +222,10 @@ public class MemberServiceImpl implements MemberService {
                 .profileImageUrl(dto.getProfileImageUrl() == null ? defaultProfileImageUrl : dto.getProfileImageUrl())
                 .role(dto.getRole())
                 .build();
+    }
+
+    private String generateUniqueAiEmail() {
+        return "ai_" + UUID.randomUUID() + "@tebutebu.ai";
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,8 @@ cookie.dev-domain=${cookie.dev-domain}
 frontend.redirect-uri=${frontend.redirect-uri}
 fortune.service.uri=${fortune.service.uri}
 fortune.service.error-message=${fortune.service.error-message}
+ai.comment.service.url=${ai.comment.service.url}
+ai.comment.default.type=${ai.comment.default.type}
 
 ranking.snapshot.duration.minutes=${ranking.snapshot.duration.minutes}
 


### PR DESCRIPTION
## ⭐ Key Changes

1. **댓글 등록 기능**
   - 인증된 사용자가 특정 프로젝트에 댓글을 작성할 수 있는 기능 추가
   - `POST /api/projects/{projectId}/comments` 엔드포인트 구현
   - 요청 바디에 `content` 포함, 서버에서 `memberId`·`projectId`로 댓글 생성

2. **댓글 수정 및 삭제 기능**
   - `PUT /api/comments/{commentId}`: 댓글 본문 수정 (작성자 본인만)
   - `DELETE /api/comments/{commentId}`: 댓글 삭제 처리 (작성자 본인만)

3. **댓글 목록 조회 (최신순 페이지네이션)**
   - 커서 기반 최신순 정렬 적용
   - `GET /api/projects/{projectId}/comments` 요청 시 `cursor-id`·`cursor-time`·`page-size` 쿼리 파라미터 사용
   - 응답은 `CommentResponseDTO` 목록과 함께 `CursorMetaDTO` 포함 (`hasNext`, `nextCursorId`, `nextCursorTime` 등)

4. **커서 페이지네이션 처리 공통화**
   - `CursorPageFactory`, `CursorPageSpec` 구조를 활용해 공통 페이지네이션 처리
   - `CommentPagingRepository`에 최신순 정렬 쿼리 정의 (QueryDSL 기반)

5. **AI 댓글 자동 생성 요청 기능**
   - 프로젝트 등록 시 `AiCommentRequestService`를 통해 AI 서버에 비동기 POST 요청 전송
   - `POST /api/projects/{projectId}/comments/ai` 엔드포인트 구현
   - AI 서버로부터 받은 상태(`pending`)만 응답, 실제 댓글 작성은 별도 워커/웹훅으로 처리

<br/>

## 🖐️ To reviewers

1. 댓글 목록 조회 시 **정렬 기준과 커서 페이징 동작이 직관적으로 처리**되는지 확인해주세요.
2. 댓글 타입(`CommentType`) 구조가 향후 **AI 댓글 확장**에 유연하게 설계되었는지 의견 부탁드립니다.
3. **컨트롤러 간 책임 분리** 구조가 API 설계 관점에서 자연스러운지 피드백 주시면 감사하겠습니다.
4. **AI 댓글 요청 흐름**(비동기 호출, 상태 응답 처리)이 적절히 구성되었는지 확인 부탁드립니다.

<br/>

## 📌 issue

- close #73 
