### PR TITLE
[#80, #81] Fix: 리프레시 토큰 클레임 수정 및 갱신 실패 시 쿠키 삭제

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/AuthController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/AuthController.java
@@ -33,22 +33,27 @@ public class AuthController {
             HttpServletRequest request,
             HttpServletResponse response
     ) {
-        TokensDTO tokens = authService.refreshTokens(authorizationHeader, refreshTokenCookie);
+        try {
+            TokensDTO tokens = authService.refreshTokens(authorizationHeader, refreshTokenCookie);
 
-        int maxAge = 60 * 60 * 24;
-        cookieUtil.addRefreshTokenCookie(
-                response,
-                refreshCookieName,
-                tokens.getRefreshToken(),
-                maxAge,
-                request.isSecure()
-        );
+            int maxAge = 60 * 60 * 24;
+            cookieUtil.addRefreshTokenCookie(
+                    response,
+                    refreshCookieName,
+                    tokens.getRefreshToken(),
+                    maxAge,
+                    request.isSecure()
+            );
 
-        Map<String, Object> body = Map.of(
-                "message", "refreshSuccess",
-                "data", Map.of("accessToken", tokens.getAccessToken())
-        );
-        return ResponseEntity.ok(body);
+            Map<String, Object> body = Map.of(
+                    "message", "refreshSuccess",
+                    "data", Map.of("accessToken", tokens.getAccessToken())
+            );
+            return ResponseEntity.ok(body);
+        } catch (Exception e) {
+            cookieUtil.deleteRefreshTokenCookie(response, refreshCookieName, request.isSecure());
+            throw e;
+        }
     }
 
 }

--- a/src/main/java/com/tebutebu/apiserver/security/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/tebutebu/apiserver/security/handler/CustomLoginSuccessHandler.java
@@ -27,12 +27,6 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
     @Value("${frontend.redirect-uri}")
     private String frontendRedirectUri;
 
-    @Value("${spring.jwt.access-token.expiration}")
-    private int accessTokenExpiration;
-
-    @Value("${spring.jwt.refresh-token.expiration}")
-    private int refreshTokenExpiration;
-
     @Value("${spring.jwt.refresh.cookie.name}")
     private String refreshCookieName;
 
@@ -46,10 +40,12 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
         Map<String, Object> originalAttributes = customOAuth2User.getAttributes();
         Map<String, Object> responseData = new HashMap<>(originalAttributes);
 
-        String accessToken = JWTUtil.generateToken(originalAttributes, accessTokenExpiration);
-        String refreshToken = JWTUtil.generateToken(originalAttributes, refreshTokenExpiration);
+        Long memberId = customOAuth2User.getMemberId();
 
-        refreshTokenService.persistRefreshToken(customOAuth2User.getMemberId(), refreshToken);
+        String accessToken = JWTUtil.generateAccessToken(originalAttributes);
+        String refreshToken = JWTUtil.generateRefreshToken(memberId);
+
+        refreshTokenService.persistRefreshToken(memberId, refreshToken);
 
         responseData.put("accessToken", accessToken);
 

--- a/src/main/java/com/tebutebu/apiserver/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/tebutebu/apiserver/security/handler/CustomLogoutHandler.java
@@ -36,7 +36,7 @@ public class CustomLogoutHandler implements LogoutHandler {
         cookie.ifPresent(c -> {
             String refreshToken = c.getValue();
             Map<String,Object> claims = JWTUtil.validateToken(refreshToken);
-            Long memberId = ((Number) claims.get("id")).longValue();
+            Long memberId = ((Number) claims.get("sub")).longValue();
             refreshTokenService.deleteByMemberId(memberId);
 
             cookieUtil.deleteRefreshTokenCookie(response, refreshCookieName, request.isSecure());

--- a/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
@@ -39,12 +39,6 @@ public class MemberServiceImpl implements MemberService {
     @Value("${spring.jwt.refresh.cookie.name}")
     private String refreshCookieName;
 
-    @Value("${spring.jwt.access-token.expiration}")
-    private int accessTokenExpiration;
-
-    @Value("${spring.jwt.refresh-token.expiration}")
-    private int refreshTokenExpiration;
-
     @Value("${default.profile.image.url}")
     private String defaultProfileImageUrl;
 
@@ -105,9 +99,11 @@ public class MemberServiceImpl implements MemberService {
         CustomOAuth2User customOAuth2User = new CustomOAuth2User(member);
         Map<String, Object> attributes = customOAuth2User.getAttributes();
 
-        String accessToken = JWTUtil.generateToken(attributes, accessTokenExpiration);
-        String refreshToken= JWTUtil.generateToken(attributes, refreshTokenExpiration);
-        refreshTokenService.persistRefreshToken(member.getId(), refreshToken);
+        Long memberId = member.getId();
+
+        String accessToken = JWTUtil.generateAccessToken(attributes);
+        String refreshToken= JWTUtil.generateRefreshToken(memberId);
+        refreshTokenService.persistRefreshToken(memberId, refreshToken);
 
         int maxAge = 60 * 60 * 24;
         cookieUtil.addRefreshTokenCookie(

--- a/src/main/java/com/tebutebu/apiserver/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/RefreshTokenServiceImpl.java
@@ -13,9 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.UUID;
 
 @Service
 @Log4j2
@@ -67,9 +65,7 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
             throw new IllegalArgumentException("invalidOrExpiredRefreshToken");
         }
 
-        Map<String, Object> claims = JWTUtil.validateToken(dto.getOldToken());
-
-        String newToken = JWTUtil.generateToken(claims, dto.getNewExpiryMinutes());
+        String newToken = JWTUtil.generateRefreshToken(dto.getMemberId());
 
         old.changeToken(newToken);
         old.changeExpiresAt(LocalDateTime.now().plusMinutes(dto.getNewExpiryMinutes()));


### PR DESCRIPTION
## ⭐ Key Changes

1. **리프레시 토큰 클레임 최소화**
   - `generateRefreshToken`에서 `email`, `roles`, `provider` 등 부가 클레임 제거
   - `sub`(memberId), `jti`, `typ` 클레임만 포함하도록 변경

2. **토큰 갱신 실패 시 쿠키 강제 삭제**
   - `/api/auth/tokens` 컨트롤러에서 예외 발생 시 `deleteRefreshTokenCookie` 호출 추가
   - 클라이언트에 만료된 리프레시 쿠키가 남지 않도록 보장

<br />

## 🖐️ To reviewers

1. `JWTUtil`의 setter 메서드를 통한 static 필드 주입이 정상 동작하는지 확인 부탁드립니다.
2. 리프레시 토큰 발급 후 디코딩 시 **sub**, **jti**, **typ** 외 불필요 정보가 포함되지 않는지 검증 부탁드립니다.
3. 토큰 갱신 실패 시 응답 헤더에 `Set-Cookie`로 리프레시 쿠키가 삭제되는지 테스트 부탁드립니다.
4. 기존 인증 흐름에 문제 없이 동작하는지 종합적으로 점검 부탁드립니다.

<br />

## 📌 issue

- close #80  
- close #81  
