### PR TITLE
[#83] Refactor: 프로젝트 삭제 로직 수정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/domain/Project.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Project.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@ToString(exclude = {"team", "images", "projectTags"})
+@ToString(exclude = {"team", "images", "projectTags", "comments"})
 public class Project extends TimeStampedEntity {
 
     @Id
@@ -68,6 +68,9 @@ public class Project extends TimeStampedEntity {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "tags", columnDefinition = "json")
     private List<TagResponseDTO> tagContents;
+
+    @OneToMany(mappedBy="project", cascade=CascadeType.ALL, orphanRemoval=true)
+    private List<Comment> comments;
 
     public void changeTitle(String title) {
         this.title = title;

--- a/src/main/java/com/tebutebu/apiserver/domain/Project.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Project.java
@@ -69,8 +69,9 @@ public class Project extends TimeStampedEntity {
     @Column(name = "tags", columnDefinition = "json")
     private List<TagResponseDTO> tagContents;
 
+    @Builder.Default
     @OneToMany(mappedBy="project", cascade=CascadeType.ALL, orphanRemoval=true)
-    private List<Comment> comments;
+    private List<Comment> comments = new ArrayList<>();
 
     public void changeTitle(String title) {
         this.title = title;


### PR DESCRIPTION
## ⭐ Key Changes

1. `Project` 엔티티에 댓글 도메인 연관관계 필드 추가
   - `List<Comment> comments`
   - `cascade = CascadeType.ALL`, `orphanRemoval = true` 설정
2. 프로젝트 삭제 시 댓글 데이터가 자동으로 삭제되도록 JPA 설정

<br />

## 🖐️ To reviewers

1. Project 삭제 시 연관된 Comment 데이터가 제대로 제거되는지 확인 부탁드립니다.
2.기존 로직과의 충돌 여부나 사이드 이펙트가 있는지도 함께 봐주시면 감사하겠습니다.

<br />

## 📌 issue

- close #83
