### PR TITLE
[#88] Refactor: 프로젝트 댓글 개수 필드 추가

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/dto/project/response/ProjectPageResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/project/response/ProjectPageResponseDTO.java
@@ -29,6 +29,8 @@ public class ProjectPageResponseDTO {
 
     private List<TagResponseDTO> tags;
 
+    private Long commentCount;
+
     private Long givedPumatiCount;
 
     private Long receivedPumatiCount;

--- a/src/main/java/com/tebutebu/apiserver/dto/project/response/ProjectResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/project/response/ProjectResponseDTO.java
@@ -40,6 +40,8 @@ public class ProjectResponseDTO {
 
     private List<TagResponseDTO> tags;
 
+    private Long commentCount;
+
     private Long givedPumatiCount;
 
     private Long receivedPumatiCount;

--- a/src/main/java/com/tebutebu/apiserver/repository/CommentRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/CommentRepository.java
@@ -15,4 +15,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "WHERE c.id = :id")
     Optional<Comment> findByIdWithMemberAndProject(@Param("id") Long id);
 
+    long countByProjectId(Long projectId);
+
 }

--- a/src/main/java/com/tebutebu/apiserver/repository/paging/comment/CommentPagingRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/paging/comment/CommentPagingRepository.java
@@ -1,11 +1,11 @@
 package com.tebutebu.apiserver.repository.paging.comment;
 
-import com.tebutebu.apiserver.domain.Comment;
+import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
 import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
 import com.tebutebu.apiserver.pagination.internal.CursorPage;
 
 public interface CommentPagingRepository {
 
-    CursorPage<Comment> findByProjectLatestCursor(Long projectId, CursorPageRequestDTO req);
+    CursorPage<CommentResponseDTO> findByProjectLatestCursor(Long projectId, CursorPageRequestDTO req);
 
 }

--- a/src/main/java/com/tebutebu/apiserver/repository/paging/comment/CommentPagingRepositoryImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/paging/comment/CommentPagingRepositoryImpl.java
@@ -4,12 +4,17 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.tebutebu.apiserver.domain.Comment;
 import com.tebutebu.apiserver.domain.QComment;
+import com.tebutebu.apiserver.dto.comment.response.AuthorDTO;
+import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
 import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
 import com.tebutebu.apiserver.pagination.factory.CursorPageFactory;
 import com.tebutebu.apiserver.pagination.factory.CursorPageSpec;
 import com.tebutebu.apiserver.pagination.internal.CursorPage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -20,7 +25,7 @@ public class CommentPagingRepositoryImpl implements CommentPagingRepository {
     private final QComment c = QComment.comment;
 
     @Override
-    public CursorPage<Comment> findByProjectLatestCursor(Long projectId, CursorPageRequestDTO req) {
+    public CursorPage<CommentResponseDTO> findByProjectLatestCursor(Long projectId, CursorPageRequestDTO req) {
         BooleanBuilder where = new BooleanBuilder();
         where.and(c.project.id.eq(projectId));
 
@@ -39,7 +44,36 @@ public class CommentPagingRepositoryImpl implements CommentPagingRepository {
                 .cursorTime(req.getCursorTime())
                 .pageSize(req.getPageSize())
                 .build();
-        return cursorPageFactory.create(spec);
+        CursorPage<Comment> page = cursorPageFactory.create(spec);
+
+        List<CommentResponseDTO> dtos = page.items().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+
+        return CursorPage.<CommentResponseDTO>builder()
+                .items(dtos)
+                .nextCursorId(page.nextCursorId())
+                .nextCursorTime(page.nextCursorTime())
+                .hasNext(page.hasNext())
+                .build();
+    }
+
+    private CommentResponseDTO toDto(Comment comment) {
+        return CommentResponseDTO.builder()
+                .id(comment.getId())
+                .projectId(comment.getProject().getId())
+                .type(comment.getType())
+                .content(comment.getContent())
+                .author(AuthorDTO.builder()
+                        .id(comment.getMember().getId())
+                        .name(comment.getMember().getName())
+                        .nickname(comment.getMember().getNickname())
+                        .course(comment.getMember().getCourse())
+                        .profileImageUrl(comment.getMember().getProfileImageUrl())
+                        .build())
+                .createdAt(comment.getCreatedAt())
+                .modifiedAt(comment.getModifiedAt())
+                .build();
     }
 
 }

--- a/src/main/java/com/tebutebu/apiserver/repository/paging/project/ProjectPagingRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/paging/project/ProjectPagingRepository.java
@@ -1,13 +1,13 @@
 package com.tebutebu.apiserver.repository.paging.project;
 
-import com.tebutebu.apiserver.domain.Project;
+import com.tebutebu.apiserver.dto.project.response.ProjectPageResponseDTO;
 import com.tebutebu.apiserver.pagination.internal.CursorPage;
 import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
 
 public interface ProjectPagingRepository {
 
-    CursorPage<Project> findByRankingCursor(CursorPageRequestDTO req);
+    CursorPage<ProjectPageResponseDTO> findByRankingCursor(CursorPageRequestDTO req);
 
-    CursorPage<Project> findByLatestCursor(CursorPageRequestDTO req);
+    CursorPage<ProjectPageResponseDTO> findByLatestCursor(CursorPageRequestDTO req);
 
 }

--- a/src/main/java/com/tebutebu/apiserver/service/CommentService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/CommentService.java
@@ -4,6 +4,7 @@ import com.tebutebu.apiserver.domain.Comment;
 import com.tebutebu.apiserver.dto.comment.ai.request.AiCommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentUpdateRequestDTO;
+import com.tebutebu.apiserver.dto.comment.response.AuthorDTO;
 import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
 import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
 import com.tebutebu.apiserver.pagination.dto.response.CursorPageResponseDTO;
@@ -35,7 +36,16 @@ public interface CommentService {
     default CommentResponseDTO entityToDTO(Comment comment) {
         return CommentResponseDTO.builder()
                 .id(comment.getId())
+                .projectId(comment.getProject().getId())
+                .type(comment.getType())
                 .content(comment.getContent())
+                .author(AuthorDTO.builder()
+                        .id(comment.getMember().getId())
+                        .name(comment.getMember().getName())
+                        .nickname(comment.getMember().getNickname())
+                        .course(comment.getMember().getCourse())
+                        .profileImageUrl(comment.getMember().getProfileImageUrl())
+                        .build())
                 .createdAt(comment.getCreatedAt())
                 .modifiedAt(comment.getModifiedAt())
                 .build();

--- a/src/main/java/com/tebutebu/apiserver/service/CommentServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/CommentServiceImpl.java
@@ -7,7 +7,6 @@ import com.tebutebu.apiserver.domain.Project;
 import com.tebutebu.apiserver.dto.comment.ai.request.AiCommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentCreateRequestDTO;
 import com.tebutebu.apiserver.dto.comment.request.CommentUpdateRequestDTO;
-import com.tebutebu.apiserver.dto.comment.response.AuthorDTO;
 import com.tebutebu.apiserver.dto.comment.response.CommentResponseDTO;
 import com.tebutebu.apiserver.dto.member.request.AiMemberSignupRequestDTO;
 import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
@@ -21,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -48,11 +46,8 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public CursorPageResponseDTO<CommentResponseDTO> getLatestCommentsByProject(Long projectId, CursorPageRequestDTO dto) {
-        CursorPage<Comment> page = commentPagingRepository.findByProjectLatestCursor(projectId, dto);
-
-        List<CommentResponseDTO> responseData = page.items().stream()
-                .map(this::entityToDTO)
-                .toList();
+        CursorPage<CommentResponseDTO> page =
+                commentPagingRepository.findByProjectLatestCursor(projectId, dto);
 
         CursorMetaDTO meta = CursorMetaDTO.builder()
                 .nextCursorId(page.nextCursorId())
@@ -61,7 +56,7 @@ public class CommentServiceImpl implements CommentService {
                 .build();
 
         return CursorPageResponseDTO.<CommentResponseDTO>builder()
-                .data(responseData)
+                .data(page.items())
                 .meta(meta)
                 .build();
     }
@@ -143,25 +138,6 @@ public class CommentServiceImpl implements CommentService {
                 .project(Project.builder().id(projectId).build())
                 .type(CommentType.USER)
                 .content(dto.getContent())
-                .build();
-    }
-
-    @Override
-    public CommentResponseDTO entityToDTO(Comment comment) {
-        return CommentResponseDTO.builder()
-                .id(comment.getId())
-                .projectId(comment.getProject().getId())
-                .type(comment.getType())
-                .content(comment.getContent())
-                .createdAt(comment.getCreatedAt())
-                .modifiedAt(comment.getModifiedAt())
-                .author(AuthorDTO.builder()
-                        .id(comment.getMember().getId())
-                        .name(comment.getMember().getName())
-                        .nickname(comment.getMember().getNickname())
-                        .course(comment.getMember().getCourse())
-                        .profileImageUrl(comment.getMember().getProfileImageUrl())
-                        .build())
                 .build();
     }
 

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -37,13 +37,14 @@ public interface ProjectService {
 
     Project dtoToEntity(ProjectCreateRequestDTO dto);
 
-    default ProjectResponseDTO entityToDTO(Project project, Team team, List<ProjectImageResponseDTO> images, List<TagResponseDTO> tags, Integer teamRank) {
+    default ProjectResponseDTO entityToDTO(Project project, Team team, List<ProjectImageResponseDTO> images, List<TagResponseDTO> tags, Integer teamRank, Long commentCount) {
         return ProjectResponseDTO.builder()
                 .id(project.getId())
                 .teamId(team.getId())
                 .teamRank(teamRank)
                 .term(team.getTerm())
                 .teamNumber(team.getNumber())
+                .commentCount(commentCount)
                 .givedPumatiCount(team.getGivedPumatiCount())
                 .receivedPumatiCount(team.getReceivedPumatiCount())
                 .badgeImageUrl(team.getBadgeImageUrl())

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectServiceImpl.java
@@ -20,6 +20,7 @@ import com.tebutebu.apiserver.pagination.dto.request.CursorPageRequestDTO;
 import com.tebutebu.apiserver.pagination.dto.response.CursorMetaDTO;
 import com.tebutebu.apiserver.pagination.dto.response.CursorPageResponseDTO;
 import com.tebutebu.apiserver.pagination.internal.CursorPage;
+import com.tebutebu.apiserver.repository.CommentRepository;
 import com.tebutebu.apiserver.repository.ProjectRepository;
 import com.tebutebu.apiserver.repository.paging.project.ProjectPagingRepository;
 import com.tebutebu.apiserver.util.exception.CustomValidationException;
@@ -40,6 +41,8 @@ public class ProjectServiceImpl implements ProjectService {
     private final ProjectRepository projectRepository;
 
     private final ProjectPagingRepository projectPagingRepository;
+
+    private final CommentRepository commentRepository;
 
     private final ProjectImageService projectImageService;
 
@@ -75,7 +78,9 @@ public class ProjectServiceImpl implements ProjectService {
                 .map(RankingItemDTO::getRank)
                 .orElse(null);
 
-        return entityToDTO(project, team, images, tags, teamRank);
+        long commentCount = commentRepository.countByProjectId(id);
+
+        return entityToDTO(project, team, images, tags, teamRank, commentCount);
     }
 
     @Override
@@ -253,11 +258,13 @@ public class ProjectServiceImpl implements ProjectService {
                         .content(tagContentDTO.getContent())
                         .build())
                 .toList();
+        long commentCount = commentRepository.countByProjectId(project.getId());
         return ProjectPageResponseDTO.builder()
                 .id(project.getId())
                 .teamId(team.getId())
                 .term(team.getTerm())
                 .teamNumber(team.getNumber())
+                .commentCount(commentCount)
                 .givedPumatiCount(team.getGivedPumatiCount())
                 .receivedPumatiCount(team.getReceivedPumatiCount())
                 .badgeImageUrl(team.getBadgeImageUrl())


### PR DESCRIPTION
## ⭐ Key Changes

1. 프로젝트 단일 조회 및 페이지네이션 응답 DTO에 `commentCount` 필드 추가
2. `ProjectPagingRepository` 반환 타입을 `CursorPage<ProjectPageResponseDTO>`로 변경
3. `CommentPagingRepository` 반환 타입을 `CursorPage<CommentResponseDTO>`로 변경
4. 서비스 계층 스트림 내 DTO 매핑 제거 및 N+1 문제 해결 로직 적용

<br />

## 🖐️ To reviewers

1. 단일 조회(`GET /api/projects/{id}`) 및 페이지네이션 응답에 `commentCount` 필드가 포함되었는지 확인해주세요.
2. 댓글 수 일괄 조회(IN 절) 로직으로 N+1 문제가 해결되었는지 검증 부탁드립니다.
3. 페이징 리포지토리들이 DTO를 반환하도록 변경된 부분이 의도대로 작동하는지 확인해주세요.

<br />

## 📌 issue

- close #88 
