### PR TITLE
[#92] Refactor: TeamResponseDTO에 projectId 및 rank 필드 추가

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/TeamController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/TeamController.java
@@ -25,6 +25,14 @@ public class TeamController {
 
     private final MemberService memberService;
 
+    @GetMapping("/{teamId}")
+    public ResponseEntity<?> getTeam(@PathVariable Long teamId) {
+        return ResponseEntity.ok(Map.of(
+                "message", "getTeamSuccess",
+                "data", teamService.get(teamId)
+        ));
+    }
+
     @PostMapping("")
     public ResponseEntity<?> register(@Valid @RequestBody TeamCreateRequestDTO dto) {
         long teamId = teamService.register(dto);

--- a/src/main/java/com/tebutebu/apiserver/dto/team/response/TeamResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/team/response/TeamResponseDTO.java
@@ -17,6 +17,10 @@ public class TeamResponseDTO {
 
     private int number;
 
+    private Long projectId;
+
+    private Integer rank;
+
     private Long givedPumatiCount;
 
     private Long receivedPumatiCount;

--- a/src/main/java/com/tebutebu/apiserver/repository/ProjectRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/ProjectRepository.java
@@ -17,6 +17,16 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
             + "WHERE p.id = :id")
     Optional<Project> findProjectWithTeamAndImagesById(@Param("id") Long id);
 
+    @Query("SELECT p.id FROM Project p WHERE p.team.id = :teamId")
+    Optional<Long> findProjectIdByTeamId(@Param("teamId") Long teamId);
+
+    @Query("SELECT DISTINCT p "
+            + "FROM Project p "
+            + "LEFT JOIN FETCH p.team t "
+            + "LEFT JOIN FETCH p.images i "
+            + "WHERE t.id = :teamId")
+    Optional<Project> findProjectByTeamId(Long teamId);
+
     boolean existsByTeamId(Long teamId);
 
     @Query("SELECT DISTINCT p FROM Project p " +

--- a/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ProjectService.java
@@ -27,6 +27,12 @@ public interface ProjectService {
     boolean existsByTeamId(Long teamId);
 
     @Transactional(readOnly = true)
+    ProjectResponseDTO getByTeamId(Long teamId);
+
+    @Transactional(readOnly = true)
+    Long getIdByTeamId(Long teamId);
+
+    @Transactional(readOnly = true)
     CursorPageResponseDTO<ProjectPageResponseDTO, CursorMetaDTO> getRankingPage(ContextCursorPageRequestDTO dto);
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/tebutebu/apiserver/service/TeamService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/TeamService.java
@@ -11,10 +11,13 @@ import java.util.List;
 @Transactional
 public interface TeamService {
 
+    @Transactional(readOnly = true)
     TeamResponseDTO get(Long id);
 
+    @Transactional(readOnly = true)
     TeamResponseDTO getByTermAndNumber(Integer term, Integer number);
 
+    @Transactional(readOnly = true)
     List<TeamListResponseDTO> getAllTeams();
 
     Long register(TeamCreateRequestDTO dto);
@@ -25,11 +28,13 @@ public interface TeamService {
 
     Team dtoToEntity(TeamCreateRequestDTO dto);
 
-    default TeamResponseDTO entityToDTO(Team team) {
+    default TeamResponseDTO entityToDTO(Team team, Long projectId, Integer rank) {
         return TeamResponseDTO.builder()
                 .id(team.getId())
                 .term(team.getTerm())
                 .number(team.getNumber())
+                .projectId(projectId)
+                .rank(rank)
                 .givedPumatiCount(team.getGivedPumatiCount())
                 .receivedPumatiCount(team.getReceivedPumatiCount())
                 .badgeImageUrl(team.getBadgeImageUrl())


### PR DESCRIPTION
## ⭐ Key Changes

1. **TeamResponseDTO**
   - `projectId`(Long) 및 `rank`(Integer) 필드 추가
   - `entityToDTO`의 매개변수를 `(Team team, Long projectId, Integer rank)`로 변경
2. **TeamServiceImpl**
   - `findTeamProjectId(Long teamId)` 메서드 추가: `existsByTeamId` 체크 후 `getByTeamId`로 ID 조회
   - `findTeamProjectRank(Long teamId)` 메서드 추가: 프로젝트 존재 여부 확인 후 `getLatestSnapshot`에서 랭크 추출
   - `get(Long)` 및 `getByTermAndNumber(...)`에서 위 두 메서드를 호출하여 DTO 빌드
3. **TeamService 인터페이스**
   - default `entityToDTO` 구현부에 `projectId` 파라미터 추가

<br />

## 🖐️ To reviewers


1. `TeamResponseDTO`가 단일 조회 API 응답에 `projectId`와 `rank`를 올바르게 포함하는지 확인해주세요.
2. `findTeamProjectId`와 `findTeamProjectRank`가 프로젝트 또는 스냅샷 미존재 시 `null`을 반환하는지 검증 부탁드립니다.
3. `getAllTeams()`, `register()`, `incrementGivedPumati()` 등 기존 기능에 영향이 없는지 통합 테스트를 실행해주세요.

<br />

## 📌 issue

- close #92 
