### PR TITLE
[#98] Fix: cursor-time 기본값이 적용되지 않던 문제 수정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -81,10 +81,14 @@ public class ProjectController {
     @GetMapping(params = "sort=latest")
     public ResponseEntity<?> scrollLatest(
             @RequestParam(name = "cursor-id", defaultValue = "0") @PositiveOrZero Long cursorId,
-            @RequestParam(name = "cursor-time", defaultValue = "#{T(LocalDateTime).now().format(T(DateTimeFormatter).ISO_DATE_TIME)}")
+            @RequestParam(name = "cursor-time", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorTime,
             @RequestParam(name = "page-size", defaultValue = "10") @Positive @Min(1) @Max(100) Integer pageSize
     ) {
+        if (cursorTime == null) {
+            cursorTime = LocalDateTime.now();
+        }
+
         CursorTimePageRequestDTO dto = CursorTimePageRequestDTO.builder()
                 .cursorId(cursorId)
                 .cursorTime(cursorTime)
@@ -102,10 +106,14 @@ public class ProjectController {
     public ResponseEntity<?> scrollComments(
             @PathVariable("projectId") Long projectId,
             @RequestParam(name = "cursor-id", defaultValue = "0") @PositiveOrZero Long cursorId,
-            @RequestParam(name = "cursor-time", defaultValue = "#{T(LocalDateTime).now().format(T(DateTimeFormatter).ISO_DATE_TIME)}")
+            @RequestParam(name = "cursor-time", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursorTime,
             @RequestParam(name = "page-size", defaultValue = "10") @Positive @Min(1) @Max(100) Integer pageSize
     ) {
+        if (cursorTime == null) {
+            cursorTime = LocalDateTime.now();
+        }
+
         CursorTimePageRequestDTO dto = CursorTimePageRequestDTO.builder()
                 .cursorId(cursorId)
                 .cursorTime(cursorTime)


### PR DESCRIPTION
## ⭐ Key Changes

1. `@RequestParam`의 defaultValue에서 사용하던 SpEL(`#{T(LocalDateTime).now()}`) 제거
2. cursor-time 파라미터가 null일 경우 메서드 내부에서 `LocalDateTime.now()`를 기본값으로 설정
3. 배포 환경(Spring Boot 실행 시)에서 발생하던 `BeanExpressionException` 방지

<br />

## 🖐️ To reviewers

1. 로컬뿐만 아니라 배포 환경에서도 cursor-time 기본값이 잘 동작하는지 확인 부탁드립니다.
2. 메서드 내부에서의 기본값 처리 방식이 코드 가독성 및 일관성 측면에서 괜찮은지도 함께 검토해주세요.

<br />

## 📌 issue

- close #98 
