### PR TITLE
fix: 일반 회원가입 시 발생하는 에러 수정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
@@ -156,8 +156,8 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomValidationException("memberNotFound"));
 
-        TeamResponseDTO teamDto = teamService.getByTermAndNumber(dto.getTerm(), dto.getTeamNumber());
-        member.changeTeam(teamDto == null ? null : Team.builder().id(teamDto.getId()).build());
+        TeamResponseDTO teamResponseDTO = teamService.getByTermAndNumber(dto.getTerm(), dto.getTeamNumber());
+        member.changeTeam(teamResponseDTO == null ? null : Team.builder().id(teamResponseDTO.getId()).build());
 
         if (dto.getProfileImageUrl() != null && !dto.getProfileImageUrl().isEmpty()) {
             member.changeProfileImageUrl(dto.getProfileImageUrl());

--- a/src/main/java/com/tebutebu/apiserver/service/TeamServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/TeamServiceImpl.java
@@ -45,7 +45,7 @@ public class TeamServiceImpl implements TeamService {
     @Override
     public TeamResponseDTO getByTermAndNumber(Integer term, Integer number) {
         if (term == null && number == null) {
-            throw new CustomValidationException("termAndNumberRequired");
+            return null;
         }
         Team team = teamRepository.findByTermAndNumber(term, number)
                 .orElseThrow(() -> new NoSuchElementException("teamNotFound"));


### PR DESCRIPTION
## ⭐ Key Changes

1. `getByTermAndNumber` 메서드에서 `term` 및 `number`가 모두 `null`일 때 `CustomValidationException` 대신 `null`을 반환하도록 변경
2. 기존의 `throw new CustomValidationException("termAndNumberRequired")` 코드를 제거하고 단순 `return null;` 로직 적용
3. `findByTermAndNumber` 이후 팀 조회, 프로젝트 ID·랭크 변환 로직은 그대로 유지

<br />

## 🖐️ To reviewers

1. `term` 또는 `number`가 `null`일 때 `getByTermAndNumber`가 `null`을 반환하는지 확인해주세요.
2. `null` 반환 시 호출부에서 NPE 등 예외 없이 안전하게 처리되는지 검토 부탁드립니다.
3. `entityToDTO(team, null, null)` 호출 시 DTO 필드(`projectId`, `rank`)가 모두 `null`로 설정되는지 확인해주세요.

<br />

## 📌 issue

- close #114
