### PR TITLE
refactor: 기본 프로필 이미지를 회원가입 시 랜덤하게 설정되도록 수정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberServiceImpl.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 @Service
@@ -39,8 +40,11 @@ public class MemberServiceImpl implements MemberService {
     @Value("${spring.jwt.refresh.cookie.name}")
     private String refreshCookieName;
 
-    @Value("${default.profile.image.url}")
-    private String defaultProfileImageUrl;
+    @Value("${default.profile.image.pu.url}")
+    private String defaultProfileImagePuUrl;
+
+    @Value("${default.profile.image.mati.url}")
+    private String defaultProfileImageMatiUrl;
 
     private final MemberRepository memberRepository;
 
@@ -142,7 +146,7 @@ public class MemberServiceImpl implements MemberService {
                 .password(passwordEncoder.encode("!A1ai-comment"))
                 .name(dto.getName())
                 .nickname(dto.getNickname())
-                .profileImageUrl(defaultProfileImageUrl)
+                .profileImageUrl(getRandomDefaultProfileImageUrl())
                 .isSocial(false)
                 .role(MemberRole.USER)
                 .state(MemberState.ACTIVE)
@@ -215,13 +219,19 @@ public class MemberServiceImpl implements MemberService {
                 .name(dto.getName())
                 .nickname(dto.getNickname())
                 .course(dto.getCourse())
-                .profileImageUrl(dto.getProfileImageUrl() == null ? defaultProfileImageUrl : dto.getProfileImageUrl())
+                .profileImageUrl(dto.getProfileImageUrl() == null ? getRandomDefaultProfileImageUrl() : dto.getProfileImageUrl())
                 .role(dto.getRole())
                 .build();
     }
 
     private String generateUniqueAiEmail() {
         return "ai_" + UUID.randomUUID() + "@tebutebu.ai";
+    }
+
+    private String getRandomDefaultProfileImageUrl() {
+        return ThreadLocalRandom.current().nextBoolean()
+                ? defaultProfileImagePuUrl
+                : defaultProfileImageMatiUrl;
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,7 +31,8 @@ ai.comment.default.type=${ai.comment.default.type}
 
 ranking.snapshot.duration.minutes=${ranking.snapshot.duration.minutes}
 
-default.profile.image.url=${default.profile.image.url}
+default.profile.image.pu.url=${default.profile.image.pu.url}
+default.profile.image.mati.url=${default.profile.image.mati.url}
 
 # registration
 spring.security.oauth2.client.registration.kakao.client-name=${kakao.client.name}


### PR DESCRIPTION
## ⭐ Key Changes
1. 기본 프로필 이미지 URL을 `defaultProfileImagePuUrl`과 `defaultProfileImageMatiUrl` 두 개로 분리
2. 회원가입 시 `ThreadLocalRandom`을 사용해 두 이미지 중 하나를 랜덤하게 선택하도록 로직 수정

<br />

## 🖐️ To reviewers
1. 랜덤 이미지 선택 로직이 의도한 대로 잘 동작하는지 확인 부탁드립니다.
2. 이미지 URL이 누락되었을 경우에만 랜덤 설정되도록 조건 처리가 적절한지 검토 부탁드립니다.

<br />

## 📌 issue
- close #118 
