### PR TITLE
[#124] Refactor: 회원 정보 응답 필드 수정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/dto/member/response/MemberResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/member/response/MemberResponseDTO.java
@@ -18,6 +18,10 @@ public class MemberResponseDTO {
 
     private Long teamId;
 
+    private Integer term;
+
+    private Integer teamNumber;
+
     private String email;
 
     private String password;

--- a/src/main/java/com/tebutebu/apiserver/service/MemberService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.tebutebu.apiserver.service;
 
 import com.tebutebu.apiserver.domain.Member;
+import com.tebutebu.apiserver.domain.Team;
 import com.tebutebu.apiserver.dto.member.request.AiMemberSignupRequestDTO;
 import com.tebutebu.apiserver.dto.member.request.MemberOAuthSignupRequestDTO;
 import com.tebutebu.apiserver.dto.member.request.MemberUpdateRequestDTO;
@@ -35,9 +36,12 @@ public interface MemberService {
     Member dtoToEntity(MemberOAuthSignupRequestDTO dto, String email);
 
     default MemberResponseDTO entityToDTO(Member member) {
+        Team team = member.getTeam();
         return MemberResponseDTO.builder()
                 .id(member.getId())
-                .teamId(member.getTeam() != null ? member.getTeam().getId() : null)
+                .teamId(team != null ? team.getId() : null)
+                .term(team != null ? team.getTerm() : null)
+                .teamNumber(team != null ? team.getNumber() : null)
                 .email(member.getEmail())
                 .isSocial(member.isSocial())
                 .name(member.getName())


### PR DESCRIPTION
## ⭐ Key Changes

1. 회원 정보에 대한 응답 필드를 수정합니다. 이제 회원 정보를 조회할 때 기수(term)과 팀(조) 번호(teamNumber)가 추가됩니다.

<br />

## 🖐️ To reviewers

1. 기수/팀 번호 정보가 필요하지 않은 곳에서도 응답에 포함되므로, 민감도 및 과도한 정보 노출 여부에 대한 피드백 부탁드립니다.

<br />

## 📌 issue

- close #124
