### PR TITLE
[#142] Feat: AI 뱃지 수정 진행 여부 관리 기능 추가

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/TeamController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/TeamController.java
@@ -114,4 +114,10 @@ public class TeamController {
         ));
     }
 
+    @PatchMapping("/{teamId}/ai-badge-status")
+    public ResponseEntity<?> resetBadgeProgress(@PathVariable Long teamId) {
+        teamService.resetAiBadgeProgress(teamId);
+        return ResponseEntity.ok(Map.of("message", "updateAiBadgeStatusSuccess"));
+    }
+
 }

--- a/src/main/java/com/tebutebu/apiserver/domain/Team.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Team.java
@@ -45,7 +45,7 @@ public class Team extends TimeStampedEntity {
     private int number;
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
-    List<Member> members;
+    private List<Member> members;
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberTeamBadge> memberBadges;
@@ -60,6 +60,10 @@ public class Team extends TimeStampedEntity {
 
     @Column(length = 512)
     private String badgeImageUrl;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean isAiBadgeInProgress = false;
 
     public void increaseGivedPumati() {
         this.givedPumatiCount++;
@@ -76,6 +80,10 @@ public class Team extends TimeStampedEntity {
     public void resetPumatiCounts() {
         this.givedPumatiCount = 0L;
         this.receivedPumatiCount = 0L;
+    }
+
+    public void setAiBadgeInProgress(boolean isAiBadgeInProgress) {
+        this.isAiBadgeInProgress = isAiBadgeInProgress;
     }
 
 }

--- a/src/main/java/com/tebutebu/apiserver/service/team/TeamService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/team/TeamService.java
@@ -36,6 +36,8 @@ public interface TeamService {
 
     void updateBadgeImageUrl(Long teamId, String badgeImageUrl);
 
+    void resetAiBadgeProgress(Long teamId);
+
     @Transactional(readOnly = true)
     CursorPageResponseDTO<MemberTeamBadgePageResponseDTO, CountCursorMetaDTO> getReceivedBadgesPage(Long memberId, ContextCountCursorPageRequestDTO req);
 

--- a/src/main/java/com/tebutebu/apiserver/service/team/TeamServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/team/TeamServiceImpl.java
@@ -141,6 +141,7 @@ public class TeamServiceImpl implements TeamService {
                 .build();
     }
 
+
     @Override
     public void increaseOrCreateBadge(Long memberId, Long teamId) {
         MemberTeamBadge badge = memberTeamBadgeRepository.findByMemberIdAndTeamId(memberId, teamId)
@@ -158,6 +159,12 @@ public class TeamServiceImpl implements TeamService {
     public void requestUpdateBadgeImage(Long teamId, BadgeImageModificationRequestDTO badgeImageModificationRequestDTO) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new NoSuchElementException("teamNotFound"));
+
+        if (team.isAiBadgeInProgress()) {
+            throw new CustomValidationException("badgeModificationInProgress");
+        }
+
+        team.setAiBadgeInProgress(true);
 
         ProjectResponseDTO project = projectService.getByTeamId(teamId);
         if (project == null) {
@@ -195,6 +202,17 @@ public class TeamServiceImpl implements TeamService {
 
         team.changeBadgeImageUrl(badgeImageUrl);
 
+        team.setAiBadgeInProgress(false);
+
+        teamRepository.save(team);
+    }
+
+    @Override
+    public void resetAiBadgeProgress(Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new NoSuchElementException("teamNotFound"));
+
+        team.setAiBadgeInProgress(false);
         teamRepository.save(team);
     }
 


### PR DESCRIPTION
## ⭐ Key Changes

1. **AI 뱃지 생성 진행 상태 관리 플래그 도입**
   - `Team` 엔티티에 `isAiBadgeInProgress` 필드 추가
   - AI 뱃지 이미지 생성 요청 시 `true`로 설정
   - 요청 완료 시(뱃지 이미지 URL 변경 시) `false`로 상태 복구
   - 서버 장애 또는 예외 상황 대응을 위한 수동 초기화 API 추가

2. **중복 요청 차단 로직 구현**
   - `isAiBadgeInProgress == true`인 경우, 동일 팀에 대해 추가 뱃지 생성 요청 불가
   - 중복 작업 및 AI 서버 자원 낭비 방지 목적

3. **API 추가: AI 뱃지 상태 수동 초기화**
   - `PATCH /api/teams/{teamId}/ai-badge-status`
   - 비정상 종료 시, 관리자 또는 클라이언트에서 상태 수동 초기화 가능

<br/>

## 🖐️ To reviewers

1. AI 뱃지 요청 시 `isAiBadgeInProgress`가 `true`로 잘 설정되는지 확인
2. 요청 완료 시 `false`로 정상적으로 복구되는지 로그 및 DB 상태 확인
3. `PATCH /api/teams/{teamId}/ai-badge-status` 호출 시 상태가 `false`로 수동 초기화되는지 확인
4. 중복 요청 차단 로직이 정상 동작하는지 (두 번 연속 요청 시 에러) 테스트

<br/>

## 📌 issue

- close #142 
