### PR TITLE
[#153] Refactor: 회원 정보 수정 로직 null-safe 및 empty-safe 방식으로 개선

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/member/MemberServiceImpl.java
@@ -165,8 +165,10 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomValidationException("memberNotFound"));
 
-        TeamResponseDTO teamResponseDTO = teamService.getByTermAndNumber(dto.getTerm(), dto.getTeamNumber());
-        member.changeTeam(teamResponseDTO == null ? null : Team.builder().id(teamResponseDTO.getId()).build());
+        if (dto.getTerm() != null && dto.getTeamNumber() != null) {
+            TeamResponseDTO teamResponseDTO = teamService.getByTermAndNumber(dto.getTerm(), dto.getTeamNumber());
+            member.changeTeam(teamResponseDTO == null ? null : Team.builder().id(teamResponseDTO.getId()).build());
+        }
 
         if (dto.getProfileImageUrl() != null && !dto.getProfileImageUrl().isEmpty()) {
             member.changeProfileImageUrl(dto.getProfileImageUrl());

--- a/src/main/java/com/tebutebu/apiserver/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/member/MemberServiceImpl.java
@@ -172,10 +172,21 @@ public class MemberServiceImpl implements MemberService {
             member.changeProfileImageUrl(dto.getProfileImageUrl());
         }
 
-        member.changeName(dto.getName());
-        member.changeNickname(dto.getNickname());
-        member.changeCourse(dto.getCourse());
-        member.changeRole(dto.getRole());
+        if (dto.getName() != null && !dto.getName().isEmpty()) {
+            member.changeName(dto.getName());
+        }
+
+        if (dto.getNickname() != null && !dto.getNickname().isEmpty()) {
+            member.changeNickname(dto.getNickname());
+        }
+
+        if (dto.getCourse() != null) {
+            member.changeCourse(dto.getCourse());
+        }
+
+        if (dto.getRole() != null) {
+            member.changeRole(dto.getRole());
+        }
 
         memberRepository.save(member);
     }


### PR DESCRIPTION
## ⭐ Key Changes

1. 회원 정보 수정 시 null 및 빈 값에 대한 필드 유지 로직 적용
2. 팀 변경 시 term, teamNumber가 모두 존재할 경우에만 팀 수정

<br />

## 🖐️ To reviewers

<br />

## 📌 issue

- close #153
