### PR TITLE
[#158] Refactor: AI 팀 뱃지 이미지 생성 및 수정 요청 메서드 분리

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/service/ai/badge/AiBadgeImageRequestServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ai/badge/AiBadgeImageRequestServiceImpl.java
@@ -24,34 +24,33 @@ public class AiBadgeImageRequestServiceImpl implements AiBadgeImageRequestServic
 
     @Override
     public void requestGenerateBadgeImage(ProjectSummaryDTO request) {
-        sendBadgeImage(request);
+        sendBadgeImage(request, HttpMethod.POST);
     }
 
     @Override
     public void requestUpdateBadgeImage(TeamBadgeStatUpdateRequestDTO request) {
-        sendBadgeImage(request);
+        sendBadgeImage(request, HttpMethod.PUT);
     }
 
-    private void sendBadgeImage(Object request) {
+    private void sendBadgeImage(Object request, HttpMethod method) {
         try {
             String jsonBody = mapper.writeValueAsString(request);
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
-
             HttpEntity<String> httpEntity = new HttpEntity<>(jsonBody, headers);
 
             ResponseEntity<Void> response = restTemplate.exchange(
                     aiBadgeServiceUrl + "/api/badges/image",
-                    HttpMethod.POST,
+                    method,
                     httpEntity,
                     Void.class
             );
 
             if (response.getStatusCode().is2xxSuccessful()) {
-                log.info(response.getBody());
+                log.info("AI Badge image request success: {}", response.getBody());
             } else {
-                log.warn("AI️ Badge image generation failed with non-2xx: {}, body: {}", response.getStatusCode(), response.getBody());
+                log.warn("AI️ Badge image request failed with non-2xx: {}, body: {}", response.getStatusCode(), response.getBody());
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
## ⭐ Key Changes

1. 뱃지 이미지 생성 요청을 POST 방식으로 분리
2. 뱃지 이미지 수정 요청을 PUT 방식으로 분리
3. 공통 전송 로직을 내부 메서드에서 통합 재사용

<br />

## 🖐️ To reviewers

1. 요청 메서드 분리 및 전송 방식 확인

<br />

## 📌 issue

- close #158 
