### PR TITLE
[#166] Fix: AiBadgeImageRequestService 비동기 메서드 리턴 타입 수정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/service/ai/badge/AiBadgeImageRequestService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ai/badge/AiBadgeImageRequestService.java
@@ -10,9 +10,8 @@ public interface AiBadgeImageRequestService {
 
     @Async
     @Transactional(readOnly = true)
-    boolean requestGenerateBadgeImage(ProjectSummaryDTO request);
+    void requestGenerateBadgeImage(ProjectSummaryDTO request);
 
-    @Async
     @Transactional(readOnly = true)
     boolean requestUpdateBadgeImage(TeamBadgeImageUpdateRequestDTO request);
 

--- a/src/main/java/com/tebutebu/apiserver/service/ai/badge/AiBadgeImageRequestServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/ai/badge/AiBadgeImageRequestServiceImpl.java
@@ -23,8 +23,8 @@ public class AiBadgeImageRequestServiceImpl implements AiBadgeImageRequestServic
     private String aiBadgeServiceUrl;
 
     @Override
-    public boolean requestGenerateBadgeImage(ProjectSummaryDTO request) {
-        return sendBadgeImage(request, HttpMethod.POST);
+    public void requestGenerateBadgeImage(ProjectSummaryDTO request) {
+        sendBadgeImage(request, HttpMethod.POST);
     }
 
     @Override

--- a/src/main/java/com/tebutebu/apiserver/service/project/ProjectServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/project/ProjectServiceImpl.java
@@ -175,10 +175,7 @@ public class ProjectServiceImpl implements ProjectService {
         Long projectId = project.getId();
         aiCommentRequestService.requestAiComment(projectId, aiDto);
 
-        boolean isAiBadgeImageRequested = aiBadgeImageRequestService.requestGenerateBadgeImage(projectSummaryDTO);
-        if (!isAiBadgeImageRequested) {
-            log.warn("AI badge generation request failed for projectId={}", projectId);
-        }
+        aiBadgeImageRequestService.requestGenerateBadgeImage(projectSummaryDTO);
 
         return projectId;
     }


### PR DESCRIPTION
## ⭐ Key Changes

1. `requestGenerateBadgeImage` 메서드 리턴 타입을 `void`로 롤백
2. `requestUpdateBadgeImage` 메서드는 즉시 결과를 받아야 하므로 `@Async` 어노테이션 제거

<br />

## 🖐️ To reviewers

1. 리턴 타입 변경 적절성 검토

<br />

## 📌 issue

- close #166 
