### PR TITLE
[#175] Refactor: refresh token만으로 access/refresh token을 재발급하도록 로직 수정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/AuthController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/AuthController.java
@@ -31,25 +31,26 @@ public class AuthController {
 
     @PutMapping("/tokens")
     public ResponseEntity<?> refreshToken(
-            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @CookieValue(value = "${spring.jwt.refresh.cookie.name}", required = false) String refreshTokenCookie,
             HttpServletRequest request,
             HttpServletResponse response
     ) {
         try {
-            TokensDTO tokens = authService.refreshTokens(authorizationHeader, refreshTokenCookie);
+            TokensDTO tokens = authService.refreshTokens(refreshTokenCookie);
+            String newAccessToken = tokens.getAccessToken();
+            String newRefreshToken = tokens.getRefreshToken();
 
             cookieUtil.addRefreshTokenCookie(
                     response,
                     refreshCookieName,
-                    tokens.getRefreshToken(),
+                    newRefreshToken,
                     refreshCookieMaxAge,
                     request.isSecure()
             );
 
             Map<String, Object> body = Map.of(
                     "message", "refreshSuccess",
-                    "data", Map.of("accessToken", tokens.getAccessToken())
+                    "data", Map.of("accessToken", newAccessToken)
             );
             return ResponseEntity.ok(body);
         } catch (Exception e) {

--- a/src/main/java/com/tebutebu/apiserver/service/auth/AuthService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/auth/AuthService.java
@@ -6,6 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface AuthService {
 
-    TokensDTO refreshTokens(String authorizationHeader, String refreshTokenCookie);
+    TokensDTO refreshTokens(String refreshTokenCookie);
 
 }


### PR DESCRIPTION
## ⭐ Key Changes

1. accessToken이 아예 없어도 `refreshToken`만으로 access/refresh 토큰 재발급 가능하도록 수정
2. access token 검증 로직 및 Authorization 헤더 처리 로직 제거
3. `sub` 클레임에서 memberId를 안전하게 파싱하여 사용자 식별

<br />

## 🖐️ To reviewers

1. access token을 완전히 제거한 흐름이 인증 서버로서 명확하고 단순한지 확인 부탁드립니다.
2. JWT 파싱 및 예외 처리 부분에서 보안적으로 누락된 부분이 있는지 검토 부탁드립니다.
3. `sub` 클레임 파싱 방식이나 예외 메시지 등에 개선 여지가 있는지 의견 주시면 감사하겠습니다.

<br />

## 📌 issue

- close #175 
