### PR TITLE
[#177] Feat: 프로젝트 구독 도메인 관련 API

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/domain/Member.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Member.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -24,7 +25,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@ToString(exclude = {"team", "comments", "attendancesDaily", "attendancesWeekly"})
+@ToString(exclude = {"team", "comments", "attendancesDaily", "attendancesWeekly", "subscriptions"})
 public class Member extends TimeStampedEntity {
 
     @Id
@@ -71,6 +72,9 @@ public class Member extends TimeStampedEntity {
 
     @OneToMany(mappedBy="member", cascade=CascadeType.ALL, orphanRemoval=true)
     private List<AttendanceWeekly> attendancesWeekly;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Subscription> subscriptions = new ArrayList<>();
 
     public void changeCourse(Course course) {
         this.course = course;

--- a/src/main/java/com/tebutebu/apiserver/domain/Project.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Project.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@ToString(exclude = {"team", "images", "projectTags", "comments"})
+@ToString(exclude = {"team", "images", "projectTags", "comments", "subscriptions"})
 public class Project extends TimeStampedEntity {
 
     @Id
@@ -65,6 +65,9 @@ public class Project extends TimeStampedEntity {
     @Builder.Default
     @OneToMany(mappedBy="project", cascade=CascadeType.ALL, orphanRemoval=true)
     private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Subscription> subscriptions = new ArrayList<>();
 
     public void changeTitle(String title) {
         this.title = title;

--- a/src/main/java/com/tebutebu/apiserver/domain/Subscription.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Subscription.java
@@ -1,0 +1,48 @@
+package com.tebutebu.apiserver.domain;
+
+import com.tebutebu.apiserver.domain.common.TimeStampedEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "subscription",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "project_id"})
+)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = {"member", "project"})
+public class Subscription extends TimeStampedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Column(name = "subscribed_at", nullable = false)
+    private LocalDateTime subscribedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void unsubscribe(LocalDateTime now) {
+        this.deletedAt = now;
+    }
+
+    public boolean isActive() {
+        return this.deletedAt == null;
+    }
+
+}

--- a/src/main/java/com/tebutebu/apiserver/global/constant/BusinessErrorMessages.java
+++ b/src/main/java/com/tebutebu/apiserver/global/constant/BusinessErrorMessages.java
@@ -31,4 +31,8 @@ public class BusinessErrorMessages {
     public static final String INVALID_FILE_EXTENSION = "invalidFileExtension";
     public static final String UNSUPPORTED_FILE_EXTENSION = "unsupportedFileExtension";
 
+    // Subscription
+    public static final String SUBSCRIPTION_NOT_FOUND = "subscriptionNotFound";
+    public static final String ALREADY_SUBSCRIBED = "alreadySubscribed";
+
 }

--- a/src/main/java/com/tebutebu/apiserver/global/errorcode/BusinessErrorCode.java
+++ b/src/main/java/com/tebutebu/apiserver/global/errorcode/BusinessErrorCode.java
@@ -31,7 +31,11 @@ public enum BusinessErrorCode implements ErrorCode {
     // PreSignedUrl
     REQUEST_COUNT_EXCEEDED(BusinessErrorMessages.REQUEST_COUNT_EXCEEDED, HttpStatus.BAD_REQUEST),
     INVALID_FILE_EXTENSION(BusinessErrorMessages.INVALID_FILE_EXTENSION, HttpStatus.BAD_REQUEST),
-    UNSUPPORTED_FILE_EXTENSION(BusinessErrorMessages.UNSUPPORTED_FILE_EXTENSION, HttpStatus.BAD_REQUEST);
+    UNSUPPORTED_FILE_EXTENSION(BusinessErrorMessages.UNSUPPORTED_FILE_EXTENSION, HttpStatus.BAD_REQUEST),
+
+    // Subscription
+    SUBSCRIPTION_NOT_FOUND(BusinessErrorMessages.SUBSCRIPTION_NOT_FOUND, HttpStatus.NOT_FOUND),
+    ALREADY_SUBSCRIBED(BusinessErrorMessages.ALREADY_SUBSCRIBED, HttpStatus.CONFLICT);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/tebutebu/apiserver/repository/SubscriptionRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/SubscriptionRepository.java
@@ -1,0 +1,17 @@
+package com.tebutebu.apiserver.repository;
+
+import com.tebutebu.apiserver.domain.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+    Optional<Subscription> findByMemberIdAndProjectIdAndDeletedAtIsNull(Long memberId, Long projectId);
+
+    List<Subscription> findAllByProjectIdAndDeletedAtIsNull(Long projectId);
+
+    boolean existsByMemberIdAndProjectIdAndDeletedAtIsNull(Long memberId, Long projectId);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/repository/paging/project/ProjectPagingRepository.java
+++ b/src/main/java/com/tebutebu/apiserver/repository/paging/project/ProjectPagingRepository.java
@@ -11,4 +11,6 @@ public interface ProjectPagingRepository {
 
     CursorPage<ProjectPageResponseDTO> findByLatestCursor(CursorTimePageRequestDTO req);
 
+    CursorPage<ProjectPageResponseDTO> findSubscribedProjectsByTerm(Long memberId, int term, CursorTimePageRequestDTO req);
+
 }

--- a/src/main/java/com/tebutebu/apiserver/service/project/ProjectService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/project/ProjectService.java
@@ -37,6 +37,9 @@ public interface ProjectService {
     CursorPageResponseDTO<ProjectPageResponseDTO, TimeCursorMetaDTO> getLatestPage(CursorTimePageRequestDTO dto);
 
     @Transactional(readOnly = true)
+    CursorPageResponseDTO<ProjectPageResponseDTO, TimeCursorMetaDTO> getSubscribedPageByTerm(Long memberId, int term, CursorTimePageRequestDTO dto);
+
+    @Transactional(readOnly = true)
     List<ProjectGithubUrlDTO> getAllGithubUrls();
 
     Long register(ProjectCreateRequestDTO dto);

--- a/src/main/java/com/tebutebu/apiserver/service/project/ProjectServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/project/ProjectServiceImpl.java
@@ -120,6 +120,24 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
+    public CursorPageResponseDTO<ProjectPageResponseDTO, TimeCursorMetaDTO> getSubscribedPageByTerm(Long memberId, int term, CursorTimePageRequestDTO dto) {
+
+        CursorPage<ProjectPageResponseDTO> page = projectPagingRepository
+                .findSubscribedProjectsByTerm(memberId, term, dto);
+
+        TimeCursorMetaDTO meta = TimeCursorMetaDTO.builder()
+                .nextCursorId(page.nextCursorId())
+                .nextCursorTime(page.nextCursorTime())
+                .hasNext(page.hasNext())
+                .build();
+
+        return CursorPageResponseDTO.<ProjectPageResponseDTO, TimeCursorMetaDTO>builder()
+                .data(page.items())
+                .meta(meta)
+                .build();
+    }
+
+    @Override
     public List<ProjectGithubUrlDTO> getAllGithubUrls() {
         return projectRepository.findAll().stream()
                 .map(p -> ProjectGithubUrlDTO.builder()

--- a/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionService.java
@@ -1,0 +1,12 @@
+package com.tebutebu.apiserver.service.subscription;
+
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface SubscriptionService {
+
+    Long subscribe(Long memberId, Long projectId);
+
+    void unsubscribe(Long memberId, Long projectId);
+
+}

--- a/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionServiceImpl.java
@@ -1,0 +1,50 @@
+package com.tebutebu.apiserver.service.subscription;
+
+import com.tebutebu.apiserver.domain.Member;
+import com.tebutebu.apiserver.domain.Project;
+import com.tebutebu.apiserver.domain.Subscription;
+import com.tebutebu.apiserver.global.errorcode.BusinessErrorCode;
+import com.tebutebu.apiserver.global.exception.BusinessException;
+import com.tebutebu.apiserver.repository.SubscriptionRepository;
+import com.tebutebu.apiserver.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionServiceImpl implements SubscriptionService {
+
+    private final SubscriptionRepository subscriptionRepository;
+
+    private final MemberService memberService;
+
+    @Override
+    public Long subscribe(Long memberId, Long projectId) {
+        boolean exists = subscriptionRepository.existsByMemberIdAndProjectIdAndDeletedAtIsNull(memberId, projectId);
+        if (exists) {
+            throw new BusinessException(BusinessErrorCode.ALREADY_SUBSCRIBED);
+        }
+
+        Member member = Member.builder().id(memberId).build();
+        Project project = Project.builder().id(projectId).build();
+
+        Subscription subscription = Subscription.builder()
+                .member(member)
+                .project(project)
+                .subscribedAt(LocalDateTime.now())
+                .build();
+
+        return subscriptionRepository.save(subscription).getId();
+    }
+
+    @Override
+    public void unsubscribe(Long memberId, Long projectId) {
+        Subscription subscription = subscriptionRepository.findByMemberIdAndProjectIdAndDeletedAtIsNull(memberId, projectId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.SUBSCRIPTION_NOT_FOUND));
+
+        subscription.unsubscribe(LocalDateTime.now());
+    }
+
+}


### PR DESCRIPTION
## ⭐ Key Changes

1. 프로젝트 구독/구독 취소 기능 구현
   - `POST /api/projects/{projectId}/subscription` 엔드포인트로 구독 등록
   - `DELETE /api/projects/{projectId}/subscription` 엔드포인트로 구독 해제
2. `SubscriptionService` 및 `SubscriptionRepository` 신규 도입
   - 구독 등록 시 중복 방지 처리 및 예외 정의
   - 구독자 조회 시 회원 상태와 구독 유효 여부 기준으로 필터링 처리
3. 구독 여부 확인 및 조건 검증을 위한 도메인 로직 및 예외 처리 추가

<br>

## 🖐️ To reviewers

1. 프로젝트 ID에 대한 유효성 검증이 적절히 수행되는지 확인 부탁드립니다.
2. 중복 구독 방지 로직이 정상적으로 동작하는지 확인 부탁드립니다.
3. 구독자 조회 결과에 불필요한 사용자 정보가 포함되어 있지 않은지 검토 부탁드립니다.
4. 인증 헤더 기반의 사용자 식별이 일관되게 처리되는지 확인 부탁드립니다.

<br>

## 📌 issue

- close #177 
