### PR TITLE
[#182] Feat: 프로젝트별 구독 여부 조회 기능 추가

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -268,4 +268,17 @@ public class ProjectController {
         return ResponseEntity.ok(Map.of("message", "unsubscribeSuccess"));
     }
 
+    @GetMapping("/{projectId}/subscription")
+    public ResponseEntity<?> checkSubscription(
+            @PathVariable Long projectId,
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        Long memberId = memberService.get(authorizationHeader).getId();
+        boolean isSubscribed = subscriptionService.isSubscribed(memberId, projectId);
+        return ResponseEntity.ok(Map.of(
+                "message", "getSubscriptionStatusSuccess",
+                "data", Map.of("isSubscribed", isSubscribed)
+        ));
+    }
+
 }

--- a/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionService.java
@@ -9,4 +9,7 @@ public interface SubscriptionService {
 
     void unsubscribe(Long memberId, Long projectId);
 
+    @Transactional(readOnly = true)
+    boolean isSubscribed(Long memberId, Long projectId);
+
 }

--- a/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionServiceImpl.java
@@ -54,4 +54,9 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         subscription.unsubscribe(LocalDateTime.now());
     }
 
+    @Override
+    public boolean isSubscribed(Long memberId, Long projectId) {
+        return subscriptionRepository.existsByMemberIdAndProjectIdAndDeletedAtIsNull(memberId, projectId);
+    }
+
 }


### PR DESCRIPTION
## ⭐ Key Changes

1. `GET /api/projects/{projectId}/subscription` 엔드포인트 추가
   - 로그인한 사용자의 프로젝트 구독 여부를 Boolean 값으로 반환
   - `Authorization` 헤더 기반 인증 처리

<br/>

## 🖐️ To reviewers

- RESTful URL 구성 및 응답 구조의 일관성
- 인증 기반 사용자 식별 처리 방식 검토

<br/>

## 📌 issue

- close #182 
