### PR TITLE
[#184] Fix: @Builder 사용 시 subscriptions 필드 기본값 무시되는 문제 수정

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
+++ b/src/main/java/com/tebutebu/apiserver/controller/ProjectController.java
@@ -268,4 +268,17 @@ public class ProjectController {
         return ResponseEntity.ok(Map.of("message", "unsubscribeSuccess"));
     }
 
+    @GetMapping("/{projectId}/subscription")
+    public ResponseEntity<?> checkSubscription(
+            @PathVariable Long projectId,
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        Long memberId = memberService.get(authorizationHeader).getId();
+        boolean isSubscribed = subscriptionService.isSubscribed(memberId, projectId);
+        return ResponseEntity.ok(Map.of(
+                "message", "getSubscriptionStatusSuccess",
+                "data", Map.of("isSubscribed", isSubscribed)
+        ));
+    }
+
 }

--- a/src/main/java/com/tebutebu/apiserver/domain/Member.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Member.java
@@ -73,6 +73,7 @@ public class Member extends TimeStampedEntity {
     @OneToMany(mappedBy="member", cascade=CascadeType.ALL, orphanRemoval=true)
     private List<AttendanceWeekly> attendancesWeekly;
 
+    @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Subscription> subscriptions = new ArrayList<>();
 

--- a/src/main/java/com/tebutebu/apiserver/domain/Project.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Project.java
@@ -66,6 +66,7 @@ public class Project extends TimeStampedEntity {
     @OneToMany(mappedBy="project", cascade=CascadeType.ALL, orphanRemoval=true)
     private List<Comment> comments = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Subscription> subscriptions = new ArrayList<>();
 

--- a/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionService.java
+++ b/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionService.java
@@ -9,4 +9,7 @@ public interface SubscriptionService {
 
     void unsubscribe(Long memberId, Long projectId);
 
+    @Transactional(readOnly = true)
+    boolean isSubscribed(Long memberId, Long projectId);
+
 }

--- a/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/subscription/SubscriptionServiceImpl.java
@@ -54,4 +54,9 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         subscription.unsubscribe(LocalDateTime.now());
     }
 
+    @Override
+    public boolean isSubscribed(Long memberId, Long projectId) {
+        return subscriptionRepository.existsByMemberIdAndProjectIdAndDeletedAtIsNull(memberId, projectId);
+    }
+
 }


### PR DESCRIPTION
## ⭐ Key Changes

1. `Member.subscriptions` 필드와 `Project.subscriptions` 필드에 `@Builder.Default` 어노테이션을 추가하여 `@Builder` 사용 시 초기화 누락 방지
2. NPE 발생 가능성 제거 및 안전한 도메인 객체 생성 보장

<br />

## 🖐️ To reviewers

1. `@Builder.Default` 적용이 적절한지 확인 부탁드립니다.

<br />

## 📌 issue

- close #184 
