### PR TITLE
[#188] Chore: Prometheus 기반 모니터링 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
 	)
 
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
+++ b/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
@@ -35,6 +35,10 @@ public class JWTCheckFilter extends OncePerRequestFilter {
         }
 
         String path = request.getRequestURI();
+        if (path.startsWith("/actuator")) {
+            return true;
+        }
+
         if (path.startsWith("/oauth2/authorization/")) {
             return true;
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,17 @@
 spring:
   profiles:
     active: ${spring.profiles.active}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,metrics,health,info
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true


### PR DESCRIPTION
## ⭐ Key Changes

1. Prometheus 기반 메트릭 수집 기능 설정
   - `micrometer-registry-prometheus`, `spring-boot-starter-actuator` 의존성 추가
   - `application.yml`에 Prometheus 메트릭 export 및 퍼센타일 히스토그램 설정 추가

2. actuator 엔드포인트 노출 및 JWT 필터 예외 처리
   - `/actuator/prometheus`, `/actuator/metrics` 등이 외부에서 접근 가능하도록 노출
   - `JWTCheckFilter`에서 `/actuator` 경로는 인증 필터 대상에서 제외되도록 설정

3. HTTP 요청 히스토그램(percentile histogram) 활성화
   - `http.server.requests`에 대한 퍼센타일 측정(`p95`, `p99` 등) 가능하도록 설정

<br>

## 🖐️ To reviewers

1. `application.yml` 내 Prometheus 관련 설정 (`metrics.export.prometheus`, `percentiles-histogram`)이 정상 적용되고 있는지 검토 부탁드립니다.
2. actuator 엔드포인트(`/actuator/prometheus`)에 접근 시 인증 없이 정상적으로 응답이 나오는지 확인 부탁드립니다.
3. Micrometer 기반 메트릭이 Prometheus 형식으로 노출되고 있는지(`curl`, Grafana 등으로) 검토 부탁드립니다.
4. JWT 필터에서 actuator 요청이 적절히 우회되도록 `shouldNotFilter()` 조건이 누락 없이 구성되었는지도 확인 부탁드립니다.

<br>

## 📌 issue

- close #188 
