### PR TITLE
[#173] Refactor: Enum Class 패키지 분리

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/domain/Comment.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Comment.java
@@ -1,6 +1,7 @@
 package com.tebutebu.apiserver.domain;
 
 import com.tebutebu.apiserver.domain.common.TimeStampedEntity;
+import com.tebutebu.apiserver.domain.enums.CommentType;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/tebutebu/apiserver/domain/CommentType.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/CommentType.java
@@ -1,7 +1,0 @@
-package com.tebutebu.apiserver.domain;
-
-public enum CommentType {
-
-    USER, AI
-
-}

--- a/src/main/java/com/tebutebu/apiserver/domain/Member.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/Member.java
@@ -1,6 +1,9 @@
 package com.tebutebu.apiserver.domain;
 
 import com.tebutebu.apiserver.domain.common.TimeStampedEntity;
+import com.tebutebu.apiserver.domain.enums.Course;
+import com.tebutebu.apiserver.domain.enums.MemberRole;
+import com.tebutebu.apiserver.domain.enums.MemberState;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/tebutebu/apiserver/domain/converter/CommentTypeConverter.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/converter/CommentTypeConverter.java
@@ -1,6 +1,6 @@
 package com.tebutebu.apiserver.domain.converter;
 
-import com.tebutebu.apiserver.domain.CommentType;
+import com.tebutebu.apiserver.domain.enums.CommentType;
 import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)

--- a/src/main/java/com/tebutebu/apiserver/domain/converter/CourseConverter.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/converter/CourseConverter.java
@@ -1,6 +1,6 @@
 package com.tebutebu.apiserver.domain.converter;
 
-import com.tebutebu.apiserver.domain.Course;
+import com.tebutebu.apiserver.domain.enums.Course;
 import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)

--- a/src/main/java/com/tebutebu/apiserver/domain/converter/MemberRoleConverter.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/converter/MemberRoleConverter.java
@@ -1,6 +1,6 @@
 package com.tebutebu.apiserver.domain.converter;
 
-import com.tebutebu.apiserver.domain.MemberRole;
+import com.tebutebu.apiserver.domain.enums.MemberRole;
 import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)

--- a/src/main/java/com/tebutebu/apiserver/domain/converter/MemberStateConverter.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/converter/MemberStateConverter.java
@@ -1,6 +1,6 @@
 package com.tebutebu.apiserver.domain.converter;
 
-import com.tebutebu.apiserver.domain.MemberState;
+import com.tebutebu.apiserver.domain.enums.MemberState;
 import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)

--- a/src/main/java/com/tebutebu/apiserver/domain/enums/CommentType.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/enums/CommentType.java
@@ -1,0 +1,7 @@
+package com.tebutebu.apiserver.domain.enums;
+
+public enum CommentType {
+
+    USER, AI
+
+}

--- a/src/main/java/com/tebutebu/apiserver/domain/enums/Course.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/enums/Course.java
@@ -1,4 +1,4 @@
-package com.tebutebu.apiserver.domain;
+package com.tebutebu.apiserver.domain.enums;
 
 public enum Course {
 

--- a/src/main/java/com/tebutebu/apiserver/domain/enums/MemberRole.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/enums/MemberRole.java
@@ -1,4 +1,4 @@
-package com.tebutebu.apiserver.domain;
+package com.tebutebu.apiserver.domain.enums;
 
 public enum MemberRole {
 

--- a/src/main/java/com/tebutebu/apiserver/domain/enums/MemberState.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/enums/MemberState.java
@@ -1,4 +1,4 @@
-package com.tebutebu.apiserver.domain;
+package com.tebutebu.apiserver.domain.enums;
 
 public enum MemberState {
 

--- a/src/main/java/com/tebutebu/apiserver/dto/ai/fortune/request/AiFortuneGenerateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/ai/fortune/request/AiFortuneGenerateRequestDTO.java
@@ -1,7 +1,7 @@
 package com.tebutebu.apiserver.dto.ai.fortune.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.tebutebu.apiserver.domain.Course;
+import com.tebutebu.apiserver.domain.enums.Course;
 import com.tebutebu.apiserver.global.constant.ValidationMessages;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/response/AuthorDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/response/AuthorDTO.java
@@ -1,6 +1,6 @@
 package com.tebutebu.apiserver.dto.comment.response;
 
-import com.tebutebu.apiserver.domain.Course;
+import com.tebutebu.apiserver.domain.enums.Course;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/tebutebu/apiserver/dto/comment/response/CommentResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/comment/response/CommentResponseDTO.java
@@ -1,6 +1,6 @@
 package com.tebutebu.apiserver.dto.comment.response;
 
-import com.tebutebu.apiserver.domain.CommentType;
+import com.tebutebu.apiserver.domain.enums.CommentType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/tebutebu/apiserver/dto/member/request/MemberOAuthSignupRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/member/request/MemberOAuthSignupRequestDTO.java
@@ -1,7 +1,7 @@
 package com.tebutebu.apiserver.dto.member.request;
 
-import com.tebutebu.apiserver.domain.Course;
-import com.tebutebu.apiserver.domain.MemberRole;
+import com.tebutebu.apiserver.domain.enums.Course;
+import com.tebutebu.apiserver.domain.enums.MemberRole;
 import com.tebutebu.apiserver.global.constant.ValidationMessages;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/com/tebutebu/apiserver/dto/member/request/MemberUpdateRequestDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/member/request/MemberUpdateRequestDTO.java
@@ -1,7 +1,7 @@
 package com.tebutebu.apiserver.dto.member.request;
 
-import com.tebutebu.apiserver.domain.Course;
-import com.tebutebu.apiserver.domain.MemberRole;
+import com.tebutebu.apiserver.domain.enums.Course;
+import com.tebutebu.apiserver.domain.enums.MemberRole;
 import com.tebutebu.apiserver.global.constant.ValidationMessages;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/com/tebutebu/apiserver/dto/member/response/MemberResponseDTO.java
+++ b/src/main/java/com/tebutebu/apiserver/dto/member/response/MemberResponseDTO.java
@@ -1,8 +1,8 @@
 package com.tebutebu.apiserver.dto.member.response;
 
-import com.tebutebu.apiserver.domain.Course;
-import com.tebutebu.apiserver.domain.MemberRole;
-import com.tebutebu.apiserver.domain.MemberState;
+import com.tebutebu.apiserver.domain.enums.Course;
+import com.tebutebu.apiserver.domain.enums.MemberRole;
+import com.tebutebu.apiserver.domain.enums.MemberState;
 import lombok.Getter;
 import lombok.Builder;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
+++ b/src/main/java/com/tebutebu/apiserver/security/filter/JWTCheckFilter.java
@@ -2,7 +2,7 @@ package com.tebutebu.apiserver.security.filter;
 
 import com.google.gson.Gson;
 import com.tebutebu.apiserver.domain.Member;
-import com.tebutebu.apiserver.domain.MemberRole;
+import com.tebutebu.apiserver.domain.enums.MemberRole;
 import com.tebutebu.apiserver.domain.Team;
 import com.tebutebu.apiserver.global.exception.BusinessException;
 import com.tebutebu.apiserver.security.dto.CustomOAuth2User;

--- a/src/main/java/com/tebutebu/apiserver/service/comment/CommentServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/comment/CommentServiceImpl.java
@@ -1,7 +1,7 @@
 package com.tebutebu.apiserver.service.comment;
 
 import com.tebutebu.apiserver.domain.Comment;
-import com.tebutebu.apiserver.domain.CommentType;
+import com.tebutebu.apiserver.domain.enums.CommentType;
 import com.tebutebu.apiserver.domain.Member;
 import com.tebutebu.apiserver.domain.Project;
 import com.tebutebu.apiserver.dto.ai.comment.request.AiCommentCreateRequestDTO;

--- a/src/main/java/com/tebutebu/apiserver/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/tebutebu/apiserver/service/member/MemberServiceImpl.java
@@ -2,8 +2,8 @@ package com.tebutebu.apiserver.service.member;
 
 import com.github.javafaker.Faker;
 import com.tebutebu.apiserver.domain.Member;
-import com.tebutebu.apiserver.domain.MemberRole;
-import com.tebutebu.apiserver.domain.MemberState;
+import com.tebutebu.apiserver.domain.enums.MemberRole;
+import com.tebutebu.apiserver.domain.enums.MemberState;
 import com.tebutebu.apiserver.domain.Team;
 import com.tebutebu.apiserver.dto.member.request.AiMemberSignupRequestDTO;
 import com.tebutebu.apiserver.dto.member.request.MemberOAuthSignupRequestDTO;
@@ -18,7 +18,6 @@ import com.tebutebu.apiserver.security.dto.CustomOAuth2User;
 import com.tebutebu.apiserver.service.oauth.OAuthService;
 import com.tebutebu.apiserver.service.token.RefreshTokenService;
 import com.tebutebu.apiserver.service.team.TeamService;
-import com.tebutebu.apiserver.global.errorcode.AuthErrorCode;
 import com.tebutebu.apiserver.global.exception.BusinessException;
 import com.tebutebu.apiserver.util.CookieUtil;
 import com.tebutebu.apiserver.util.JWTUtil;


### PR DESCRIPTION
## ⭐ Key Changes

1. enum 전용 패키지 `domain.enums` 생성
   - `MemberRole`, `MemberStatus`, `Course`, `CommentType` 등 기존 enum 클래스들을 이동
   - 도메인 엔티티와의 명확한 책임 분리를 통해 응집도 향상

2. import 경로 전면 수정
   - enum 패키지 변경에 따라 전체 프로젝트 내 관련 클래스의 import 경로 일괄 수정

3. 향후 유지보수성 및 재사용성 개선
   - enum의 참조 위치가 명확해져 코드 탐색과 관리 용이성 향상

<br>

## 🖐️ To reviewers

1. 모든 enum 클래스가 새 패키지(`domain.enums`)로 정상 이동되었는지 확인 부탁드립니다.
2. enum 참조 경로 수정이 누락 없이 반영되었는지, 특히 컴파일 오류 발생 여부를 중심으로 검토해 주세요.

<br>

## 📌 issue

- close #173  
