### PR TITLE
[#200] Refactor: 운세 생성 실패 시 재요청 로직 추가

### DIFF
--- a/src/main/java/com/tebutebu/apiserver/domain/AttendanceDaily.java
+++ b/src/main/java/com/tebutebu/apiserver/domain/AttendanceDaily.java
@@ -40,4 +40,8 @@ public class AttendanceDaily extends TimeStampedEntity {
     @Column(name = "checked_at", nullable = false)
     private LocalDateTime checkedAt;
 
+    public void updateDevLuck(String newDevLuckOverall) {
+        this.devLuckOverall = newDevLuckOverall;
+    }
+
 }


### PR DESCRIPTION
## ⭐ Key Changes

1. 운세 생성 실패 시 재요청 로직 추가
   - 기존에 출석 체크된 운세 내용이 실패 메시지(`fortune.service.error-message`)일 경우, AI 운세 서버에 재요청을 수행하여 운세 내용을 갱신하도록 수정

2. 중복 로직 분리
   - `AiFortuneGenerateRequestDTO` 생성 및 운세 요청 로직을 `requestDevLuck()` 메서드로 추출하여 중복 제거 및 가독성 향상

3. 출석 API 응답 일관성 유지
   - 운세 재생성 여부와 관계없이 `AttendanceDailyResponseDTO`를 일관된 방식으로 반환

<br>

## 🖐️ To reviewers

1. 운세 재요청 로직이 정상적으로 동작하는지, 실패 메시지 조건이 명확하게 반영되었는지 확인 부탁드립니다.

<br>

## 📌 issue

- close #200 
